### PR TITLE
Upgrading the SDK to the latest documentation version

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can configure your android project to get the Kuzzle's android SDK from jcen
             jcenter()
         }
     }
-    compile 'io.kuzzle:sdk-android:1.4.1'
+    compile 'io.kuzzle:sdk-android:1.4.2'
 
 ## Basic usage
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'jacoco-android'
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 
-version = "1.4.1"
+version = "1.4.2"
 
 buildscript {
     repositories {

--- a/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
+++ b/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
@@ -1532,15 +1532,15 @@ public class Kuzzle {
    * @param headers the headers
    */
   public void addHeaders(JSONObject query, final JSONObject headers) {
-    for (Iterator iterator = headers.keys(); iterator.hasNext(); ) {
-      String key = (String) iterator.next();
-      if (query.isNull(key)) {
-        try {
+    try {
+      for (Iterator iterator = headers.keys(); iterator.hasNext(); ) {
+        String key = (String) iterator.next();
+        if (query.isNull(key)) {
           query.put(key, headers.get(key));
-        } catch (JSONException e) {
-          throw new RuntimeException(e);
         }
       }
+    } catch (JSONException e) {
+      throw new RuntimeException(e);
     }
   }
 

--- a/src/main/java/io/kuzzle/sdk/security/AbstractKuzzleSecurityDocument.java
+++ b/src/main/java/io/kuzzle/sdk/security/AbstractKuzzleSecurityDocument.java
@@ -127,4 +127,23 @@ public class AbstractKuzzleSecurityDocument {
   public void delete() throws JSONException {
     this.delete(null, null);
   }
+
+  /**
+   * Getter for the "id" property
+   *
+   * @return the document id
+   */
+  public String getId() {
+    return this.id;
+  }
+
+  /**
+   * Getter for the "content" property
+   *
+   * @return the document content
+   */
+  public JSONObject getContent() {
+    return this.content;
+  }
+
 }

--- a/src/main/java/io/kuzzle/sdk/security/KuzzleUser.java
+++ b/src/main/java/io/kuzzle/sdk/security/KuzzleUser.java
@@ -197,4 +197,14 @@ public class KuzzleUser extends AbstractKuzzleSecurityDocument {
 
     return data;
   }
+
+  /**
+   * Returns the associated profiles
+   *
+   * @return an array of KuzzleProfile objects
+   */
+  public KuzzleProfile[] getProfiles() {
+    KuzzleProfile[] profiles = {this.profile};
+    return profiles;
+  }
 }

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/connectionManagementTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/connectionManagementTest.java
@@ -232,6 +232,7 @@ public class connectionManagementTest {
 
   @Test
   public void testDisconnect() {
+    kuzzle.setState(KuzzleStates.CONNECTED);
     assertNotNull(kuzzle.getSocket());
     kuzzle.disconnect();
     assertNull(kuzzle.getSocket());

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/constructorTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/constructorTest.java
@@ -21,6 +21,7 @@ import io.socket.client.Socket;
 
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -85,8 +86,11 @@ public class constructorTest {
     verify(kuzzle).setHeaders(any(JSONObject.class), eq(false));
   }
 
-  @Test
+  @Test(expected = RuntimeException.class)
   public void testSetHeaders() throws JSONException {
+    kuzzle.setHeaders(null, true);
+    kuzzle.setHeaders(new JSONObject());
+    assertNotNull(kuzzle.getHeaders());
     JSONObject content = new JSONObject();
     content.put("foo", "bar");
     kuzzle.setHeaders(content);
@@ -94,15 +98,21 @@ public class constructorTest {
     content.put("foo", "baz");
     kuzzle.setHeaders(content, true);
     assertEquals(kuzzle.getHeaders().getString("foo"), "baz");
+    JSONObject fake = spy(new JSONObject());
+    doThrow(JSONException.class).when(fake).keys();
+    kuzzle.setHeaders(fake, false);
   }
 
-  @Test
+  @Test(expected = RuntimeException.class)
   public void testAddHeaders() throws JSONException {
     JSONObject query = new JSONObject();
     JSONObject headers = new JSONObject();
     headers.put("testPurpose", "test");
     kuzzle.addHeaders(query, headers);
     assertEquals(query.get("testPurpose"), "test");
+    JSONObject fake = mock(JSONObject.class);
+    doThrow(JSONException.class).when(fake).keys();
+    kuzzle.addHeaders(new JSONObject(), fake);
   }
 
   @Test

--- a/src/test/java/io/kuzzle/test/security/KuzzleProfileTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleProfileTest.java
@@ -137,9 +137,11 @@ public class KuzzleProfileTest {
         }
       }
     });
+    stubProfile.save(mock(KuzzleOptions.class));
 
     ArgumentCaptor argument = ArgumentCaptor.forClass(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class);
     verify(kuzzle, times(1)).query((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.capture(), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
+    verify(kuzzle, times(1)).query((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.capture(), any(JSONObject.class), any(KuzzleOptions.class));
     assertEquals(((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.getValue()).controller, "security");
     assertEquals(((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.getValue()).action, "createOrReplaceProfile");
   }

--- a/src/test/java/io/kuzzle/test/security/KuzzleRoleTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleRoleTest.java
@@ -25,13 +25,11 @@ import static org.mockito.Mockito.verify;
 public class KuzzleRoleTest {
   private Kuzzle kuzzle;
   private KuzzleRole stubRole;
-  private KuzzleResponseListener listener;
 
   @Before
   public void setUp() throws JSONException {
     kuzzle = mock(Kuzzle.class);
     kuzzle.security = new KuzzleSecurity(kuzzle);
-    listener = mock(KuzzleResponseListener.class);
     stubRole = new KuzzleRole(kuzzle, "foo", null);
   }
 
@@ -70,9 +68,11 @@ public class KuzzleRoleTest {
         }
       }
     });
+    stubRole.save(mock(KuzzleOptions.class));
 
     ArgumentCaptor argument = ArgumentCaptor.forClass(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class);
     verify(kuzzle, times(1)).query((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.capture(), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
+    verify(kuzzle, times(1)).query((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.capture(), any(JSONObject.class), any(KuzzleOptions.class));
     assertEquals(((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.getValue()).controller, "security");
     assertEquals(((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.getValue()).action, "createOrReplaceRole");
   }

--- a/src/test/java/io/kuzzle/test/security/KuzzleUserTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleUserTest.java
@@ -218,9 +218,11 @@ public class KuzzleUserTest {
         }
       }
     });
+    stubUser.save(mock(KuzzleOptions.class));
 
     ArgumentCaptor argument = ArgumentCaptor.forClass(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class);
     verify(kuzzle, times(1)).query((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.capture(), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
+    verify(kuzzle, times(1)).query((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.capture(), any(JSONObject.class), any(KuzzleOptions.class));
     assertEquals(((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.getValue()).controller, "security");
     assertEquals(((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.getValue()).action, "createOrReplaceUser");
   }
@@ -242,5 +244,21 @@ public class KuzzleUserTest {
     assertEquals(serialized.getString("_id"), stubUser.id);
     assertEquals(serialized.getJSONObject("body").getString("foo"), "bar");
     assertEquals(serialized.getJSONObject("body").getString("profile"), stubUser.profile.id);
+  }
+
+  @Test
+  public void testGetProfiles() throws JSONException {
+    JSONObject stubProfile = new JSONObject(
+        "{" +
+            "\"profile\": {" +
+            "\"_id\": \"bar\"," +
+            "\"_source\": {" +
+            "\"bohemian\": \"rhapsody\"" +
+            "}" +
+            "}" +
+            "}"
+    );
+    KuzzleUser user = new KuzzleUser(kuzzle, "foo", stubProfile);
+    assertEquals(user.getProfiles()[0].getId(), "bar");
   }
 }


### PR DESCRIPTION
:warning: Do not merge this pull request yet, I still have many unit tests to add to improve code coverage and catch potential bugs

**Kuzzle object**
- Overhauled the event system
- Overhauled the subscription management system to allow multisubscriptions to work on a same room
- Made all non-documented methods either private or protected, instead of public
- The constructor now follows the current SDK documentation
- Removed the `login*` options and made the `login` method work as documented
- Default properties values are now handled by the `KuzzleOptions` object, instead of being maintained in both `Kuzzle` AND `KuzzleOptions` objects
- Added missing getter/setter on documented properties
- `connect` now reinitializes the socket if it has been closed, e.g. by a `disconnect` call
- Socket initialization now takes constructor options into account
- The JWT Token is now checked upon reconnection and removed if it has expired
- The JWT Token has been removed from the headers and are now automatically added before sending a request (except on a `checkToken` call)
- Now automatically resubscribes all rooms upon reconnection
- Added a timer so that the same event cannot be emitted twice in a short period of time
- the `stopQueuing` method is now spelled correctly

**KuzzleDataCollection**
- cannot be initialized without a `Kuzzle` instance anymore
- added a getter for the `index` property
- `headers` are now copied from the Kuzzle instance and can now be changed
- now properly set the document versions when necessary
- removed the `updateMapping` method
- `replaceDocument` and `updateDocument` now take a `JSONObject` content instead of a `KuzzleDocument`

**KuzzleDataMapping**
- `headers` are now copied from the Kuzzle instance and can now be changed
- `refresh` now resolves to a new `KuzzleDataMapping` object, keeping the caller unmodified

**KuzzleDocument**
- does not inherit from `JSONObject` anymore, allowing to check the document consistency more easily
- `headers` are now copied from the Kuzzle instance and can now be changed
- added a `version` property and a getter on it
- most of the `content` manipulating methods now throw a `JSONException` exception, instead of converting it to a `RuntimeException`
- `subscribe` now throws a `IllegalStateException` if the document has no ID, instead of a `RuntimeException`
- added a `serialize` method

**KuzzleRoom**
- added a timer to the `renew` method to avoid renewing the same room multiple times in a short period of time
- `renew` now only registers itself to `Kuzzle` if not in a connected state
- `unsubscribe` now immediately stops listening, instead of waiting for a response from a Kuzzle server
- `unsubscribe` now waits for all pending subscriptions to complete before submitting an unsubscription request to a Kuzzle server, and only if no new `KuzzleRoom` instance subscribed to the same room
- now postpones method calls while subscribing

**MISC.**
- Event names are now lowercased, to match the SDK documentation
- Setters in the `KuzzleOptions` class now return the object itself to allow chaining calls
- Reorganised unit tests to make them easier to maintain
- Prefixed most of internal objects with `Kuzzle...`
