### PR TITLE
updated setJwtToken behavior

### DIFF
--- a/src/main/java/io/kuzzle/sdk/core/KuzzleRoom.java
+++ b/src/main/java/io/kuzzle/sdk/core/KuzzleRoom.java
@@ -210,7 +210,7 @@ public class KuzzleRoom {
         String key = ((JSONObject) args).getString("requestId");
 
         if (((JSONObject) args).getString("action").equals("jwtTokenExpired")) {
-          KuzzleRoom.this.kuzzle.setJwtToken(null);
+          KuzzleRoom.this.kuzzle.jwtToken = null;
           KuzzleRoom.this.kuzzle.emitEvent(KuzzleEvent.jwtTokenExpired);
         }
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/eventSystemTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/eventSystemTest.java
@@ -9,7 +9,6 @@ import org.mockito.stubbing.Answer;
 
 import java.net.URISyntaxException;
 
-import io.kuzzle.sdk.core.Kuzzle;
 import io.kuzzle.sdk.core.KuzzleOptions;
 import io.kuzzle.sdk.enums.KuzzleEvent;
 import io.kuzzle.sdk.enums.Mode;
@@ -30,7 +29,6 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 public class eventSystemTest {

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/setJwtTokenTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/setJwtTokenTest.java
@@ -1,0 +1,94 @@
+package io.kuzzle.test.core.Kuzzle;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.net.URISyntaxException;
+
+import io.kuzzle.sdk.core.KuzzleOptions;
+import io.kuzzle.sdk.enums.KuzzleEvent;
+import io.kuzzle.sdk.enums.Mode;
+import io.kuzzle.test.testUtils.KuzzleExtend;
+import io.socket.client.Socket;
+
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertNull;
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.TestCase.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class setJwtTokenTest {
+  private KuzzleExtend kuzzle;
+  private Socket s;
+
+  @Before
+  public void setUp() throws URISyntaxException {
+    KuzzleOptions options = new KuzzleOptions();
+    options.setConnect(Mode.MANUAL);
+    options.setDefaultIndex("testIndex");
+
+    s = mock(Socket.class);
+    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle.setSocket(s);
+
+    kuzzle = spy(kuzzle);
+    doNothing().when(kuzzle).renewSubscriptions();
+    doNothing().when(kuzzle).emitEvent(any(KuzzleEvent.class), any(JSONObject.class));
+  }
+
+  @Test
+  public void shouldHandleStringToken() throws JSONException {
+    kuzzle.setJwtToken("foobar");
+    assertEquals("foobar", kuzzle.getJwtToken());
+
+    ArgumentCaptor loginResult = ArgumentCaptor.forClass(JSONObject.class);
+    verify(kuzzle).emitEvent(eq(KuzzleEvent.loginAttempt), (JSONObject)loginResult.capture());
+    assertTrue(((JSONObject) loginResult.getValue()).getBoolean("success"));
+
+    verify(kuzzle).renewSubscriptions();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldThrowWithNullKuzzleResponse() throws JSONException {
+    kuzzle.setJwtToken((JSONObject) null);
+  }
+
+  @Test
+  public void shouldHandleValidKuzzleResponse() throws JSONException {
+    JSONObject validResponse = new JSONObject()
+      .put("result", new JSONObject()
+        .put("jwt", "foobar")
+      );
+
+    kuzzle.setJwtToken(validResponse);
+    assertEquals("foobar", kuzzle.getJwtToken());
+
+    ArgumentCaptor loginResult = ArgumentCaptor.forClass(JSONObject.class);
+    verify(kuzzle).emitEvent(eq(KuzzleEvent.loginAttempt), (JSONObject)loginResult.capture());
+    assertTrue(((JSONObject) loginResult.getValue()).getBoolean("success"));
+
+    verify(kuzzle).renewSubscriptions();
+  }
+
+  @Test
+  public void shouldHandleInvalidResponse() throws JSONException {
+    kuzzle.setJwtToken(new JSONObject());
+    assertNull(kuzzle.getJwtToken());
+
+    ArgumentCaptor loginResult = ArgumentCaptor.forClass(JSONObject.class);
+    verify(kuzzle).emitEvent(eq(KuzzleEvent.loginAttempt), (JSONObject)loginResult.capture());
+    assertFalse(((JSONObject) loginResult.getValue()).getBoolean("success"));
+
+    verify(kuzzle, never()).renewSubscriptions();
+  }
+}

--- a/src/test/java/io/kuzzle/test/testUtils/KuzzleExtend.java
+++ b/src/test/java/io/kuzzle/test/testUtils/KuzzleExtend.java
@@ -121,4 +121,8 @@ public class KuzzleExtend extends Kuzzle {
     super.emitEvent(event, args);
   }
 
+  public void renewSubscriptions() {
+    super.renewSubscriptions();
+  }
+
 }


### PR DESCRIPTION
- Added the possibility for `setJwtToken` to take a JSONObject containing a Kuzzle response as an argument
- Bugfix: subscription renewal wasn't performed with 2-steps authentication process
- Added unit tests
