### PR TITLE
fixed AbstractKuzzleSecurityDocument.update

### DIFF
--- a/src/main/java/io/kuzzle/sdk/security/AbstractKuzzleSecurityDocument.java
+++ b/src/main/java/io/kuzzle/sdk/security/AbstractKuzzleSecurityDocument.java
@@ -1,6 +1,5 @@
 package io.kuzzle.sdk.security;
 
-import android.accounts.AbstractAccountAuthenticator;
 import android.support.annotation.NonNull;
 
 import org.json.JSONException;

--- a/src/main/java/io/kuzzle/sdk/security/AbstractKuzzleSecurityDocument.java
+++ b/src/main/java/io/kuzzle/sdk/security/AbstractKuzzleSecurityDocument.java
@@ -1,5 +1,6 @@
 package io.kuzzle.sdk.security;
 
+import android.accounts.AbstractAccountAuthenticator;
 import android.support.annotation.NonNull;
 
 import org.json.JSONException;
@@ -175,40 +176,59 @@ public class AbstractKuzzleSecurityDocument {
     return this.content;
   }
 
-  public void update() throws JSONException {
-    this.update(null, null);
-  }
-
-  public void update(final KuzzleOptions options) throws JSONException {
-    this.update(options, null);
+  /**
+   * Perform a partial update on this object
+   *
+   * @param content - content used to update the object
+   * @throws JSONException
+   */
+  public void update(final JSONObject content) throws JSONException {
+    this.update(content, null, null);
   }
 
   /**
-   * Update.
+   * Perform a partial update on this object
    *
+   * @param content - content used to update the object
+   * @param options - optional arguments
+   * @throws JSONException
+   */
+  public void update(final JSONObject content, final KuzzleOptions options) throws JSONException {
+    this.update(content, options, null);
+  }
+
+  /**
+   * Perform a partial update on this object
+   *
+   * @param content - content used to update the object
    * @param listener the listener
    * @throws JSONException the json exception
    */
-  public void update(final KuzzleResponseListener<String> listener) throws JSONException {
-    this.update(null, listener);
+  public void update(final JSONObject content, final KuzzleResponseListener<AbstractKuzzleSecurityDocument> listener) throws JSONException {
+    this.update(content, null, listener);
   }
 
   /**
-   * Update.
+   * Perform a partial update on this object
    *
+   * @param content - content used to update the object
    * @param options  the options
    * @param listener the listener
    * @throws JSONException the json exception
    */
-  public void update(final KuzzleOptions options, final KuzzleResponseListener<String> listener) throws JSONException {
-    JSONObject data = new JSONObject().put("_id", this.id);
+  public void update(final JSONObject content, final KuzzleOptions options, final KuzzleResponseListener<AbstractKuzzleSecurityDocument> listener) throws JSONException {
+    JSONObject data = new JSONObject()
+      .put("_id", this.id)
+      .put("body", content);
 
     if (listener != null) {
       this.kuzzle.query(kuzzleSecurity.buildQueryArgs(this.updateActionName), data, options, new OnQueryDoneListener() {
         @Override
         public void onSuccess(JSONObject response) {
           try {
-            listener.onSuccess(response.getJSONObject("result").getString("_id"));
+            JSONObject updatedContent = response.getJSONObject("result").getJSONObject("_source");
+            AbstractKuzzleSecurityDocument.this.setContent(updatedContent);
+            listener.onSuccess(AbstractKuzzleSecurityDocument.this);
           } catch (JSONException e) {
             throw new RuntimeException(e);
           }
@@ -221,7 +241,7 @@ public class AbstractKuzzleSecurityDocument {
       });
     }
     else {
-      this.kuzzle.query(kuzzleSecurity.buildQueryArgs(this.deleteActionName), data, options);
+      this.kuzzle.query(kuzzleSecurity.buildQueryArgs(this.updateActionName), data, options);
     }
   }
 

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/AbstractKuzzleSecurityDocumentTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/AbstractKuzzleSecurityDocumentTest.java
@@ -12,6 +12,7 @@ import io.kuzzle.sdk.core.Kuzzle;
 import io.kuzzle.sdk.core.KuzzleOptions;
 import io.kuzzle.sdk.listeners.KuzzleResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
+import io.kuzzle.sdk.security.AbstractKuzzleSecurityDocument;
 import io.kuzzle.sdk.security.KuzzleRole;
 import io.kuzzle.sdk.security.KuzzleSecurity;
 
@@ -79,7 +80,7 @@ public class AbstractKuzzleSecurityDocumentTest {
     doAnswer(new Answer() {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {
-        JSONObject content = new JSONObject("{\"result\": { \"_id\": \"foo\" }}");
+        JSONObject content = new JSONObject("{\"result\": { \"_id\": \"foo\", \"_source\": {} }}");
 
         ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(content);
         ((OnQueryDoneListener) invocation.getArguments()[3]).onError(new JSONObject().put("error", "stub"));
@@ -129,10 +130,12 @@ public class AbstractKuzzleSecurityDocumentTest {
 
   @Test
   public void testUpdate() throws JSONException {
+    JSONObject content = new JSONObject();
+
     doAnswer(new Answer() {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {
-        JSONObject content = new JSONObject("{\"result\": { \"_id\": \"foo\" }}");
+        JSONObject content = new JSONObject("{\"result\": { \"_id\": \"foo\", \"_source\": {} }}");
 
         ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(content);
         ((OnQueryDoneListener) invocation.getArguments()[3]).onError(new JSONObject().put("error", "stub"));
@@ -140,10 +143,10 @@ public class AbstractKuzzleSecurityDocumentTest {
       }
     }).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
 
-    stubRole.update(new KuzzleResponseListener<String>() {
+    stubRole.update(content, new KuzzleResponseListener<AbstractKuzzleSecurityDocument>() {
       @Override
-      public void onSuccess(String response) {
-        assertEquals(response, "foo");
+      public void onSuccess(AbstractKuzzleSecurityDocument response) {
+        assertEquals(response.getId(), "foo");
       }
 
       @Override
@@ -155,8 +158,8 @@ public class AbstractKuzzleSecurityDocumentTest {
         }
       }
     });
-    stubRole.update();
-    stubRole.update(mock(KuzzleOptions.class));
+    stubRole.update(content);
+    stubRole.update(content, mock(KuzzleOptions.class));
     verify(kuzzle, times(2)).query(any(Kuzzle.QueryArgs.class), any(JSONObject.class), any(KuzzleOptions.class));
     verify(kuzzle).query(any(Kuzzle.QueryArgs.class), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
   }
@@ -172,7 +175,7 @@ public class AbstractKuzzleSecurityDocumentTest {
       }
     }).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
 
-    stubRole.update(listener);
+    stubRole.update(new JSONObject(), listener);
   }
 
 }


### PR DESCRIPTION
Fixes on the `AbstractKuzzleSecurityDocument.update` method:
- made a JSONObject content required, as stated in the documentation
- now calls the `update` security method instead of the `delete` one when no callback is provided
- the callback now resolves to an updated version of itself, instead of a string containing the document ID
- now updates itself with the new content
- added missing javadoc
