### PR TITLE
KUZ-463 ElaticSearch (Auto)Refresh functions

### DIFF
--- a/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
+++ b/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
@@ -2193,4 +2193,349 @@ public class Kuzzle {
     }
     return this;
   }
+
+  /**
+   * Forces the current/provided index to refresh
+   *
+   * @return itself
+   */
+  public Kuzzle refreshIndex() {
+    return this.refreshIndex(null, null, null);
+  }
+
+  /**
+   * Forces the current/provided index to refresh
+   *
+   * @param index
+   * @return itself
+   */
+  public Kuzzle refreshIndex(String index) {
+    return this.refreshIndex(index, null, null);
+  }
+
+  /**
+   * Forces the current/provided index to refresh
+   *
+   * @param index
+   * @param listener
+   * @return itself
+   */
+  public Kuzzle refreshIndex(String index, final KuzzleResponseListener<JSONObject> listener) {
+    return this.refreshIndex(index, null, listener);
+  }
+
+  /**
+   * Forces the current/provided index to refresh
+   *
+   * @param index
+   * @param options
+   * @return itself
+   */
+  public Kuzzle refreshIndex(String index, KuzzleOptions options) {
+    return this.refreshIndex(index, options, null);
+  }
+
+  /**
+   * Forces the current/provided index to refresh
+   *
+   * @param options
+   * @return itself
+   */
+  public Kuzzle refreshIndex(KuzzleOptions options) {
+    return this.refreshIndex(null, options, null);
+  }
+
+  /**
+   * Forces the current/provided index to refresh
+   *
+   * @param options
+   * @param listener
+   * @return itself
+   */
+  public Kuzzle refreshIndex(KuzzleOptions options, final KuzzleResponseListener<JSONObject> listener) {
+    return this.refreshIndex(null, options, listener);
+  }
+
+  /**
+   * Forces the current/provided index to refresh
+   *
+   * @param listener
+   * @return itself
+   */
+  public Kuzzle refreshIndex(final KuzzleResponseListener<JSONObject> listener) {
+    return this.refreshIndex(null, null, listener);
+  }
+
+  /**
+   * Forces the current/provided index to refresh
+   *
+   * @param index
+   * @param options
+   * @param listener
+   * @return itself
+   */
+  public Kuzzle refreshIndex(String index, KuzzleOptions options, final KuzzleResponseListener<JSONObject> listener) {
+    if (index == null) {
+      if (this.defaultIndex == null) {
+        throw new IllegalArgumentException("Kuzzle.refreshIndex: index required");
+      } else {
+        index = this.defaultIndex;
+      }
+    }
+
+    QueryArgs args = new QueryArgs();
+    args.index = index;
+    args.controller = "admin";
+    args.action = "refreshIndex";
+    JSONObject request = new JSONObject();
+
+    try {
+      this.query(args, request, options, new OnQueryDoneListener() {
+        @Override
+        public void onSuccess(JSONObject response) {
+          if (listener == null) {
+            return;
+          }
+
+          try {
+            JSONObject result = response.getJSONObject("result");
+
+            listener.onSuccess(result);
+          } catch (JSONException e) {
+            throw new RuntimeException(e);
+          }
+        }
+
+        @Override
+        public void onError(JSONObject error) {
+          if (listener == null) {
+            return;
+          }
+
+          listener.onError(error);
+        }
+      });
+    } catch (JSONException e) {
+      throw new RuntimeException(e);
+    }
+
+    return this;
+  }
+
+
+  /**
+   * Gets the current/provided index autorefresh status
+   *
+   * @param listener
+   * @return itself
+   */
+  public Kuzzle getAutoRefresh(@NonNull final KuzzleResponseListener<Boolean> listener) {
+    return this.getAutoRefresh(null, null, listener);
+  }
+
+  /**
+   * Gets the current/provided index autorefresh status
+   *
+   * @param index
+   * @param listener
+   * @return itself
+   */
+  public Kuzzle getAutoRefresh(String index, @NonNull final KuzzleResponseListener<Boolean> listener) {
+    return this.getAutoRefresh(index, null, listener);
+  }
+
+  /**
+   * Gets the current/provided index autorefresh status
+   *
+   * @param options
+   * @param listener
+   * @return itself
+   */
+  public Kuzzle getAutoRefresh(KuzzleOptions options, @NonNull final KuzzleResponseListener<Boolean> listener) {
+    return this.getAutoRefresh(null, options, listener);
+  }
+
+  /**
+   * Gets the current/provided index autorefresh status
+   *
+   * @param index
+   * @param options
+   * @param listener
+   * @return itself
+   */
+  public Kuzzle getAutoRefresh(String index, KuzzleOptions options, @NonNull final KuzzleResponseListener<Boolean> listener) {
+    if (listener == null) {
+      throw new IllegalArgumentException("Kuzzle.getAutoRefresh: listener required");
+    }
+
+    if (index == null) {
+      if (this.defaultIndex == null) {
+        throw new IllegalArgumentException("Kuzzle.getAutoRefresh: index required");
+      } else {
+        index = this.defaultIndex;
+      }
+    }
+
+    QueryArgs args = new QueryArgs();
+    args.index = index;
+    args.controller = "admin";
+    args.action = "getAutoRefresh";
+    JSONObject request = new JSONObject();
+
+    try {
+      this.query(args, request, options, new OnQueryDoneListener() {
+        @Override
+        public void onSuccess(JSONObject response) {
+          try {
+            Boolean result = response.getBoolean("result");
+            listener.onSuccess(result);
+          } catch(JSONException e) { throw new RuntimeException(e); }
+        }
+
+        @Override
+        public void onError(JSONObject error) { listener.onError(error); }
+      });
+    } catch(JSONException e) {
+      throw new RuntimeException(e);
+    }
+
+    return this;
+  }
+
+  /**
+   * (Un)Sets the autorefresh status for the current/given index
+   *
+   * @param autoRefresh
+   * @return itself
+   */
+  public Kuzzle setAutoRefresh(Boolean autoRefresh) {
+    return this.setAutoRefresh(null, autoRefresh, null, null);
+  }
+
+  /**
+   * (Un)Sets the autorefresh status for the current/given index
+   *
+   * @param autoRefresh
+   * @param listener
+   * @return itself
+   */
+  public Kuzzle setAutoRefresh(Boolean autoRefresh, KuzzleResponseListener<Boolean> listener) {
+    return this.setAutoRefresh(null, autoRefresh, null, listener);
+  }
+
+  /**
+   * (Un)Sets the autorefresh status for the current/given index
+   *
+   * @param index
+   * @param autoRefresh
+   * @return itself
+   */
+  public Kuzzle setAutoRefresh(String index, Boolean autoRefresh) {
+    return this.setAutoRefresh(index, autoRefresh, null, null);
+  }
+
+  /**
+   * (Un)Sets the autorefresh status for the current/given index
+   *
+   * @param autoRefresh
+   * @param options
+   * @return itself
+   */
+  public Kuzzle setAutoRefresh(Boolean autoRefresh, KuzzleOptions options) {
+    return this.setAutoRefresh(null, autoRefresh, options, null);
+  }
+
+  /**
+   * (Un)Sets the autorefresh status for the current/given index
+   *
+   * @param index
+   * @param autoRefresh
+   * @param options
+   * @return itself
+   */
+  public Kuzzle setAutoRefresh(String index, Boolean autoRefresh, KuzzleOptions options) {
+    return this.setAutoRefresh(index, autoRefresh, options, null);
+  }
+
+  /**
+   * (Un)Sets the autorefresh status for the current/given index
+   *
+   * @param index
+   * @param autoRefresh
+   * @param listener
+   * @return itself
+   */
+  public Kuzzle setAutoRefresh(String index, Boolean autoRefresh, final KuzzleResponseListener<Boolean> listener) {
+    return this.setAutoRefresh(index, autoRefresh, null, listener);
+  }
+
+  /**
+   * (Un)Sets the autorefresh status for the current/given index
+   *
+   * @param autoRefresh
+   * @param options
+   * @param listener
+   * @return itself
+   */
+  public Kuzzle setAutoRefresh(Boolean autoRefresh, KuzzleOptions options, final KuzzleResponseListener<Boolean> listener) {
+    return this.setAutoRefresh(null, autoRefresh, options, listener);
+  }
+
+  /**
+   * (Un)Sets the autorefresh status for the current/given index
+   *
+   * @param index
+   * @param autoRefresh
+   * @param options
+   * @param listener
+   * @return itself
+   */
+  public Kuzzle setAutoRefresh(String index, Boolean autoRefresh, KuzzleOptions options, final KuzzleResponseListener<Boolean> listener) {
+    if (index == null) {
+      if (this.defaultIndex == null) {
+        throw new IllegalArgumentException("Kuzzle.setAutoRefresh: index required");
+      } else {
+        index = this.defaultIndex;
+      }
+    }
+
+    QueryArgs args = new QueryArgs();
+    args.index = index;
+    args.controller = "admin";
+    args.action = "setAutoRefresh";
+    JSONObject request;
+
+    try {
+      request = new JSONObject().put("body", new JSONObject().put("autoRefresh", autoRefresh));
+      this.query(args, request, options, new OnQueryDoneListener() {
+        @Override
+        public void onSuccess(JSONObject response) {
+          if (listener == null) {
+            return;
+          }
+
+          try {
+            Boolean result = response.getBoolean("result");
+            listener.onSuccess(result);
+          } catch (JSONException e) { throw new RuntimeException(e); }
+        }
+
+        @Override
+        public void onError(JSONObject error) {
+          if (listener != null) {
+            listener.onError(error);
+          }
+        }
+      });
+    } catch(JSONException e) {
+      throw  new RuntimeException(e);
+    }
+
+    return this;
+  }
+
+
+
+
+
 }

--- a/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
+++ b/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
@@ -2231,7 +2231,7 @@ public class Kuzzle {
    * @param options
    * @return itself
    */
-  public Kuzzle refreshIndex(String index, KuzzleOptions options) {
+  public Kuzzle refreshIndex(String index, final KuzzleOptions options) {
     return this.refreshIndex(index, options, null);
   }
 
@@ -2241,7 +2241,7 @@ public class Kuzzle {
    * @param options
    * @return itself
    */
-  public Kuzzle refreshIndex(KuzzleOptions options) {
+  public Kuzzle refreshIndex(final KuzzleOptions options) {
     return this.refreshIndex(null, options, null);
   }
 
@@ -2252,7 +2252,7 @@ public class Kuzzle {
    * @param listener
    * @return itself
    */
-  public Kuzzle refreshIndex(KuzzleOptions options, final KuzzleResponseListener<JSONObject> listener) {
+  public Kuzzle refreshIndex(final KuzzleOptions options, final KuzzleResponseListener<JSONObject> listener) {
     return this.refreshIndex(null, options, listener);
   }
 
@@ -2274,7 +2274,7 @@ public class Kuzzle {
    * @param listener
    * @return itself
    */
-  public Kuzzle refreshIndex(String index, KuzzleOptions options, final KuzzleResponseListener<JSONObject> listener) {
+  public Kuzzle refreshIndex(String index, final KuzzleOptions options, final KuzzleResponseListener<JSONObject> listener) {
     if (index == null) {
       if (this.defaultIndex == null) {
         throw new IllegalArgumentException("Kuzzle.refreshIndex: index required");
@@ -2363,7 +2363,7 @@ public class Kuzzle {
    * @param listener
    * @return itself
    */
-  public Kuzzle getAutoRefresh(String index, KuzzleOptions options, @NonNull final KuzzleResponseListener<Boolean> listener) {
+  public Kuzzle getAutoRefresh(String index, final KuzzleOptions options, @NonNull final KuzzleResponseListener<Boolean> listener) {
     if (listener == null) {
       throw new IllegalArgumentException("Kuzzle.getAutoRefresh: listener required");
     }
@@ -2387,7 +2387,7 @@ public class Kuzzle {
         @Override
         public void onSuccess(JSONObject response) {
           try {
-            Boolean result = response.getBoolean("result");
+            boolean result = response.getBoolean("result");
             listener.onSuccess(result);
           } catch(JSONException e) { throw new RuntimeException(e); }
         }
@@ -2408,7 +2408,7 @@ public class Kuzzle {
    * @param autoRefresh
    * @return itself
    */
-  public Kuzzle setAutoRefresh(Boolean autoRefresh) {
+  public Kuzzle setAutoRefresh(final boolean autoRefresh) {
     return this.setAutoRefresh(null, autoRefresh, null, null);
   }
 
@@ -2419,7 +2419,7 @@ public class Kuzzle {
    * @param listener
    * @return itself
    */
-  public Kuzzle setAutoRefresh(Boolean autoRefresh, KuzzleResponseListener<Boolean> listener) {
+  public Kuzzle setAutoRefresh(final boolean autoRefresh, final KuzzleResponseListener<Boolean> listener) {
     return this.setAutoRefresh(null, autoRefresh, null, listener);
   }
 
@@ -2430,7 +2430,7 @@ public class Kuzzle {
    * @param autoRefresh
    * @return itself
    */
-  public Kuzzle setAutoRefresh(String index, Boolean autoRefresh) {
+  public Kuzzle setAutoRefresh(String index, final boolean autoRefresh) {
     return this.setAutoRefresh(index, autoRefresh, null, null);
   }
 
@@ -2441,7 +2441,7 @@ public class Kuzzle {
    * @param options
    * @return itself
    */
-  public Kuzzle setAutoRefresh(Boolean autoRefresh, KuzzleOptions options) {
+  public Kuzzle setAutoRefresh(final boolean autoRefresh, final KuzzleOptions options) {
     return this.setAutoRefresh(null, autoRefresh, options, null);
   }
 
@@ -2453,7 +2453,7 @@ public class Kuzzle {
    * @param options
    * @return itself
    */
-  public Kuzzle setAutoRefresh(String index, Boolean autoRefresh, KuzzleOptions options) {
+  public Kuzzle setAutoRefresh(String index, final boolean autoRefresh, final KuzzleOptions options) {
     return this.setAutoRefresh(index, autoRefresh, options, null);
   }
 
@@ -2465,7 +2465,7 @@ public class Kuzzle {
    * @param listener
    * @return itself
    */
-  public Kuzzle setAutoRefresh(String index, Boolean autoRefresh, final KuzzleResponseListener<Boolean> listener) {
+  public Kuzzle setAutoRefresh(String index, final boolean autoRefresh, final KuzzleResponseListener<Boolean> listener) {
     return this.setAutoRefresh(index, autoRefresh, null, listener);
   }
 
@@ -2477,7 +2477,7 @@ public class Kuzzle {
    * @param listener
    * @return itself
    */
-  public Kuzzle setAutoRefresh(Boolean autoRefresh, KuzzleOptions options, final KuzzleResponseListener<Boolean> listener) {
+  public Kuzzle setAutoRefresh(final boolean autoRefresh, final KuzzleOptions options, final KuzzleResponseListener<Boolean> listener) {
     return this.setAutoRefresh(null, autoRefresh, options, listener);
   }
 
@@ -2490,7 +2490,7 @@ public class Kuzzle {
    * @param listener
    * @return itself
    */
-  public Kuzzle setAutoRefresh(String index, Boolean autoRefresh, KuzzleOptions options, final KuzzleResponseListener<Boolean> listener) {
+  public Kuzzle setAutoRefresh(String index, final boolean autoRefresh, final KuzzleOptions options, final KuzzleResponseListener<Boolean> listener) {
     if (index == null) {
       if (this.defaultIndex == null) {
         throw new IllegalArgumentException("Kuzzle.setAutoRefresh: index required");
@@ -2515,7 +2515,7 @@ public class Kuzzle {
           }
 
           try {
-            Boolean result = response.getBoolean("result");
+            boolean result = response.getBoolean("result");
             listener.onSuccess(result);
           } catch (JSONException e) { throw new RuntimeException(e); }
         }
@@ -2533,9 +2533,5 @@ public class Kuzzle {
 
     return this;
   }
-
-
-
-
 
 }

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/getAutoRefreshTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/getAutoRefreshTest.java
@@ -1,0 +1,117 @@
+package io.kuzzle.test.core.Kuzzle;
+
+import java.net.URISyntaxException;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+
+import io.kuzzle.sdk.core.Kuzzle;
+import io.kuzzle.sdk.core.KuzzleOptions;
+import io.kuzzle.sdk.enums.Mode;
+import io.kuzzle.sdk.listeners.KuzzleResponseListener;
+import io.kuzzle.sdk.listeners.OnQueryDoneListener;
+import io.kuzzle.test.testUtils.KuzzleExtend;
+import io.socket.client.Socket;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class getAutoRefreshTest {
+  private KuzzleExtend kuzzle;
+  private KuzzleResponseListener listener;
+
+
+  @Before
+  public void setup() throws URISyntaxException {
+    KuzzleOptions options = new KuzzleOptions();
+    options.setConnect(Mode.MANUAL);
+    options.setDefaultIndex("testIndex");
+
+    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle.setSocket(mock(Socket.class));
+
+    listener = mock(KuzzleResponseListener.class);
+  }
+
+  @Test
+  public void testSignatureVariants() {
+    KuzzleOptions options = mock(KuzzleOptions.class);
+
+    kuzzle = spy(kuzzle);
+
+    kuzzle.getAutoRefresh(listener);
+    kuzzle.getAutoRefresh(options, listener);
+    kuzzle.getAutoRefresh("foo", listener);
+
+    verify(kuzzle, times(3)).getAutoRefresh(any(String.class), any(KuzzleOptions.class), any(KuzzleResponseListener.class));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetAutoRefreshWithIllegalListener() {
+    kuzzle.getAutoRefresh("index", null, null);
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testGetAutoRefreshException() throws JSONException {
+    kuzzle = spy(kuzzle);
+    doThrow(JSONException.class).when(listener).onSuccess(any(JSONArray.class));
+    doAnswer(new Answer() {
+      @Override
+      public Object answer(InvocationOnMock invocation) throws Throwable {
+        ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(new JSONObject().put("result", true));
+        return null;
+      }
+    }).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
+    kuzzle.getAutoRefresh(listener);
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testGetAutoRefreshQueryException() throws JSONException {
+    kuzzle = spy(kuzzle);
+    doThrow(JSONException.class).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
+    kuzzle.getAutoRefresh(listener);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetAutoRefreshIllegalDefaultIndex() {
+    kuzzle = spy(kuzzle);
+    kuzzle.setSuperDefaultIndex(null);
+    kuzzle.getAutoRefresh(null, mock(KuzzleOptions.class), listener);
+  }
+
+  @Test
+  public void testGetAutoRefresh() throws URISyntaxException, JSONException {
+    kuzzle = spy(kuzzle);
+    doAnswer(new Answer() {
+      @Override
+      public Object answer(InvocationOnMock invocation) throws Throwable {
+        ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(new JSONObject().put("result", true));
+        ((OnQueryDoneListener) invocation.getArguments()[3]).onError(mock(JSONObject.class));
+        return null;
+      }
+    }).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
+
+    kuzzle.getAutoRefresh(listener);
+    kuzzle.getAutoRefresh(mock(KuzzleOptions.class), listener);
+
+    ArgumentCaptor argument = ArgumentCaptor.forClass(Kuzzle.QueryArgs.class);
+    verify(kuzzle, times(2)).query((Kuzzle.QueryArgs) argument.capture(), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
+    assertEquals(((Kuzzle.QueryArgs) argument.getValue()).controller, "admin");
+    assertEquals(((Kuzzle.QueryArgs) argument.getValue()).action, "getAutoRefresh");
+    assertEquals(((Kuzzle.QueryArgs) argument.getValue()).index, kuzzle.getDefaultIndex());
+  }
+
+}

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/refreshIndexTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/refreshIndexTest.java
@@ -1,0 +1,116 @@
+package io.kuzzle.test.core.Kuzzle;
+
+import java.net.URISyntaxException;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+
+import io.kuzzle.sdk.core.Kuzzle;
+import io.kuzzle.sdk.core.KuzzleOptions;
+import io.kuzzle.sdk.enums.Mode;
+import io.kuzzle.sdk.listeners.KuzzleResponseListener;
+import io.kuzzle.sdk.listeners.OnQueryDoneListener;
+import io.kuzzle.test.testUtils.KuzzleExtend;
+import io.socket.client.Socket;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+
+public class refreshIndexTest {
+  private KuzzleExtend kuzzle;
+  private KuzzleResponseListener listener;
+
+  @Before
+  public void setup() throws URISyntaxException {
+    KuzzleOptions options = new KuzzleOptions();
+    options.setConnect(Mode.MANUAL);
+    options.setDefaultIndex("testIndex");
+
+    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle.setSocket(mock(Socket.class));
+
+    listener = mock(KuzzleResponseListener.class);
+  }
+
+  @Test
+  public void testAllSignatureVariants() {
+    KuzzleOptions options = mock(KuzzleOptions.class);
+
+    kuzzle = spy(kuzzle);
+
+    kuzzle.refreshIndex();
+    kuzzle.refreshIndex(options);
+    kuzzle.refreshIndex(options, listener);
+    kuzzle.refreshIndex(listener);
+    kuzzle.refreshIndex("foo");
+    kuzzle.refreshIndex("foo", options);
+    kuzzle.refreshIndex("foo", listener);
+
+    verify(kuzzle, times(7)).refreshIndex(any(String.class), any(KuzzleOptions.class), any(KuzzleResponseListener.class));
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testRefreshIndexException() throws JSONException {
+    kuzzle = spy(kuzzle);
+    doThrow(JSONException.class).when(listener).onSuccess(any(JSONArray.class));
+    doAnswer(new Answer() {
+      @Override
+      public Object answer(InvocationOnMock invocation) throws Throwable {
+        ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(new JSONObject().put("result", new JSONObject().put("_shards", new JSONObject())));
+        return null;
+      }
+    }).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
+    kuzzle.refreshIndex(listener);
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testRefreshIndexQueryException() throws JSONException {
+    kuzzle = spy(kuzzle);
+    doThrow(JSONException.class).when(kuzzle).query(any(Kuzzle.QueryArgs.class), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
+    kuzzle.refreshIndex(listener);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testRefreshIndexIllegalDefaultIndex() {
+    kuzzle = spy(kuzzle);
+    kuzzle.setSuperDefaultIndex(null);
+    kuzzle.refreshIndex(null, mock(KuzzleOptions.class), listener);
+  }
+
+  @Test
+  public void testRefreshIndex() throws URISyntaxException, JSONException {
+    kuzzle = spy(kuzzle);
+    doAnswer(new Answer() {
+      @Override
+      public Object answer(InvocationOnMock invocation) throws Throwable {
+        ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(new JSONObject().put("result", new JSONObject().put("_shards", new JSONObject())));
+        ((OnQueryDoneListener) invocation.getArguments()[3]).onError(mock(JSONObject.class));
+        return null;
+      }
+    }).when(kuzzle).query(any(Kuzzle.QueryArgs.class), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
+
+    kuzzle.refreshIndex();
+    kuzzle.refreshIndex(listener);
+    kuzzle.refreshIndex(mock(KuzzleOptions.class), listener);
+    ArgumentCaptor argument = ArgumentCaptor.forClass(Kuzzle.QueryArgs.class);
+    verify(kuzzle, times(3)).query((Kuzzle.QueryArgs) argument.capture(), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
+    assertEquals(((Kuzzle.QueryArgs) argument.getValue()).controller, "admin");
+    assertEquals(((Kuzzle.QueryArgs) argument.getValue()).action, "refreshIndex");
+    assertEquals(((Kuzzle.QueryArgs) argument.getValue()).index, kuzzle.getDefaultIndex());
+  }
+
+}

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/setAutoRefreshTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/setAutoRefreshTest.java
@@ -1,0 +1,117 @@
+package io.kuzzle.test.core.Kuzzle;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.net.URISyntaxException;
+
+import io.kuzzle.sdk.core.Kuzzle;
+import io.kuzzle.sdk.core.KuzzleOptions;
+import io.kuzzle.sdk.enums.Mode;
+import io.kuzzle.sdk.listeners.KuzzleResponseListener;
+import io.kuzzle.sdk.listeners.OnQueryDoneListener;
+import io.kuzzle.test.testUtils.KuzzleExtend;
+import io.socket.client.Socket;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class setAutoRefreshTest {
+  private KuzzleExtend kuzzle;
+  private KuzzleResponseListener listener;
+
+
+  @Before
+  public void setup() throws URISyntaxException {
+    KuzzleOptions options = new KuzzleOptions();
+    options.setConnect(Mode.MANUAL);
+    options.setDefaultIndex("testIndex");
+
+    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle.setSocket(mock(Socket.class));
+
+    listener = mock(KuzzleResponseListener.class);
+  }
+
+  @Test
+  public void testSignatureVariants() {
+    KuzzleOptions options = mock(KuzzleOptions.class);
+
+    kuzzle = spy(kuzzle);
+
+    kuzzle.setAutoRefresh(true);
+    kuzzle.setAutoRefresh(true, options);
+    kuzzle.setAutoRefresh(true, options, listener);
+    kuzzle.setAutoRefresh("foo", true);
+    kuzzle.setAutoRefresh("foo", true, options);
+    kuzzle.setAutoRefresh("foo", true, listener);
+
+    verify(kuzzle, times(6)).setAutoRefresh(any(String.class), any(Boolean.class), any(KuzzleOptions.class), any(KuzzleResponseListener.class));
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testSetAutoRefreshException() throws JSONException {
+    kuzzle = spy(kuzzle);
+    doThrow(JSONException.class).when(listener).onSuccess(any(JSONArray.class));
+    doAnswer(new Answer() {
+      @Override
+      public Object answer(InvocationOnMock invocation) throws Throwable {
+        ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(new JSONObject().put("result", true));
+        return null;
+      }
+    }).when(kuzzle).query(any(Kuzzle.QueryArgs.class), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
+    kuzzle.setAutoRefresh(true, listener);
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testSetAutoRefreshQueryException() throws JSONException {
+    kuzzle = spy(kuzzle);
+    doThrow(JSONException.class).when(kuzzle).query(any(Kuzzle.QueryArgs.class), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
+    kuzzle.setAutoRefresh(true, listener);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testSetAutoRefreshIllegalDefaultIndex() {
+    kuzzle = spy(kuzzle);
+    kuzzle.setSuperDefaultIndex(null);
+    kuzzle.setAutoRefresh(null, true, mock(KuzzleOptions.class), listener);
+  }
+
+  @Test
+  public void testGetAutoRefresh() throws URISyntaxException, JSONException {
+    kuzzle = spy(kuzzle);
+    doAnswer(new Answer() {
+      @Override
+      public Object answer(InvocationOnMock invocation) throws Throwable {
+        ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(new JSONObject().put("result", true));
+        ((OnQueryDoneListener) invocation.getArguments()[3]).onError(mock(JSONObject.class));
+        return null;
+      }
+    }).when(kuzzle).query(any(Kuzzle.QueryArgs.class), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
+
+    kuzzle.setAutoRefresh(true);
+    kuzzle.setAutoRefresh(true, listener);
+    kuzzle.setAutoRefresh(true, mock(KuzzleOptions.class), listener);
+
+    ArgumentCaptor argument = ArgumentCaptor.forClass(Kuzzle.QueryArgs.class);
+    ArgumentCaptor request = ArgumentCaptor.forClass(JSONObject.class);
+    verify(kuzzle, times(3)).query((Kuzzle.QueryArgs) argument.capture(), (JSONObject) request.capture(), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
+    assertEquals(((Kuzzle.QueryArgs) argument.getValue()).controller, "admin");
+    assertEquals(((Kuzzle.QueryArgs) argument.getValue()).action, "setAutoRefresh");
+    assertEquals(((Kuzzle.QueryArgs) argument.getValue()).index, kuzzle.getDefaultIndex());
+    assertEquals(((JSONObject) request.getValue()).getJSONObject("body").getBoolean("autoRefresh"), true);
+  }
+
+}


### PR DESCRIPTION
Follows [the implementation of (auto)refresh features](https://github.com/kuzzleio/kuzzle/pull/257) in Kuzzle.
# Changelog

Three new functions are implemented on `Kuzzle` main object:
## refreshIndex([index], [options], [cb])

Forces the [refresh](https://www.elastic.co/guide/en/elasticsearch/guide/current/near-real-time.html#refresh-api) of the current/given index.
## getAutoRefresh([index], [options], cb)

Gets the `autoRefresh` status ofr the current/given index.
## setAutoRefresh([index], autoRefresh, [options], [cb])

(Un)Sets the `autoRefresh` flag for the current/given index.
