### PR TITLE
Kuzzle constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Official Kuzzle Android SDK
 ======
 
-This SDK version requires Kuzzle v1.0.0-beta.6 or higher.
+This SDK version requires Kuzzle v1.0.0-RC5 or higher.
 
 ## About Kuzzle
 
@@ -16,7 +16,7 @@ You can access the Kuzzle repository on [Github](https://github.com/kuzzleio/kuz
 
 ## SDK Documentation
 
-The complete SDK documentation is available [here](http://kuzzleio.github.io/sdk-documentation)
+The complete SDK documentation is available [here](http://kuzzle.io/sdk-documentation)
 
 ## Installation
 
@@ -27,12 +27,12 @@ You can configure your android project to get the Kuzzle's android SDK from jcen
             jcenter()
         }
     }
-    compile 'io.kuzzle:sdk-android:1.6.0'
+    compile 'io.kuzzle:sdk-android:2.0.0'
 
 ## Basic usage
 
 ```java
-Kuzzle kuzzle = new Kuzzle("http://host.url", "index", new ResponseListener<Void>() {
+Kuzzle kuzzle = new Kuzzle("host", new ResponseListener<Void>() {
 @Override
 public void onSuccess(Void object) {
     // Handle success
@@ -64,7 +64,7 @@ myDocument.publish();
 
 ## Adding metadata
 
-As stated [here](http://kuzzleio.github.io/kuzzle-api-documentation/#sending-metadata) you can add metadata to a subscription.
+As stated [here](http://kuzzle.io/api-reference/#sending-metadata) you can add metadata to a subscription.
 
 ```java
 KuzzleOptions options = new KuzzleOptions();
@@ -87,7 +87,7 @@ If you have the kuzzle-plugin-auth-passport-local installed you can login using 
 
 ```java
 KuzzleOptions options = new KuzzleOptions();
-kuzzle = new Kuzzle("http://localhost:7512", "index", options);
+kuzzle = new Kuzzle("localhost", options);
 ```
 
 ## Login with an OAuth strategy

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'jacoco-android'
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 
-version = "1.7.0"
+version = "2.0.0"
 
 buildscript {
     repositories {
@@ -14,13 +14,13 @@ buildscript {
         classpath 'com.android.tools.build:gradle:2.1.2'
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
     }
 }
 
 android {
     compileSdkVersion 23
-    buildToolsVersion '23.0.1'
+    buildToolsVersion '23.0.2'
     defaultConfig {
         minSdkVersion 10
         targetSdkVersion 10

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
 
 android {
     compileSdkVersion 23
-    buildToolsVersion '23.0.2'
+    buildToolsVersion '23.0.1'
     defaultConfig {
         minSdkVersion 10
         targetSdkVersion 10

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'jacoco-android'
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 
-version = "1.6.1"
+version = "1.7.0"
 
 buildscript {
     repositories {
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:2.1.2'
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
@@ -20,7 +20,7 @@ buildscript {
 
 android {
     compileSdkVersion 23
-    buildToolsVersion '23.0.1'
+    buildToolsVersion '23.0.2'
     defaultConfig {
         minSdkVersion 10
         targetSdkVersion 10

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,4 @@
 # org.gradle.parallel=true
 #Mon Feb 08 14:31:09 CET 2016
 systemProp.http.proxyHost=
-systemProp.http.proxyPort=3128
+systemProp.http.proxyPort=

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Oct 22 17:22:25 CEST 2015
+#Thu Aug 04 16:08:53 CEST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
+++ b/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
@@ -76,9 +76,13 @@ public class Kuzzle {
    */
   protected JSONObject metadata;
   /**
-   * The Url.
+   * The target Kuzzle URL
    */
   protected String url;
+  /**
+   * Target Kuzzle network port
+   */
+  protected Integer port;
   /**
    * The Connection callback.
    */
@@ -170,9 +174,8 @@ public class Kuzzle {
   private KuzzleOfflineQueueLoader  offlineQueueLoader;
 
   /**
-   * The constant security.
+   * Security static class
    */
-// Security static class
   public KuzzleSecurity security;
 
   private KuzzleResponseListener<JSONObject>  loginCallback;
@@ -227,14 +230,14 @@ public class Kuzzle {
   /**
    * Kuzzle object constructor.
    *
-   * @param url                the url
+   * @param host               target host name or IP address
    * @param options            the options
    * @param connectionCallback the connection callback
    * @throws URISyntaxException the uri syntax exception
    */
-  public Kuzzle(@NonNull final String url, final KuzzleOptions options, final KuzzleResponseListener<Void> connectionCallback) throws URISyntaxException {
-    if (url == null || url.isEmpty()) {
-      throw new IllegalArgumentException("Url can't be empty");
+  public Kuzzle(@NonNull final String host, final KuzzleOptions options, final KuzzleResponseListener<Void> connectionCallback) throws URISyntaxException {
+    if (host == null || host.isEmpty()) {
+      throw new IllegalArgumentException("Host name/address can't be empty");
     }
 
     KuzzleOptions opt = (options != null ? options : new KuzzleOptions());
@@ -246,12 +249,13 @@ public class Kuzzle {
     this.defaultIndex = opt.getDefaultIndex();
     this.headers = opt.getHeaders();
     this.metadata = opt.getMetadata();
+    this.port = opt.getPort();
     this.queueMaxSize = opt.getQueueMaxSize();
     this.queueTTL = opt.getQueueTTL();
     this.reconnectionDelay = opt.getReconnectionDelay();
     this.replayInterval = opt.getReplayInterval();
 
-    this.url = url;
+    this.url = "http://" + host + ":" + this.port;
     this.connectionCallback = connectionCallback;
 
     if (socket == null) {
@@ -275,33 +279,33 @@ public class Kuzzle {
   /**
    * Instantiates a new Kuzzle.
    *
-   * @param url the url
+   * @param host target Kuzzle host name or IP address
    * @throws URISyntaxException the uri syntax exception
    */
-  public Kuzzle(@NonNull final String url) throws URISyntaxException {
-    this(url, null, null);
+  public Kuzzle(@NonNull final String host) throws URISyntaxException {
+    this(host, null, null);
   }
 
   /**
    * Instantiates a new Kuzzle.
    *
-   * @param url the url
+   * @param host target Kuzzle host name or IP address
    * @param cb  the cb
    * @throws URISyntaxException the uri syntax exception
    */
-  public Kuzzle(@NonNull final String url, final KuzzleResponseListener<Void> cb) throws URISyntaxException {
-    this(url, null, cb);
+  public Kuzzle(@NonNull final String host, final KuzzleResponseListener<Void> cb) throws URISyntaxException {
+    this(host, null, cb);
   }
 
   /**
    * Instantiates a new Kuzzle.
    *
-   * @param url     the url
+   * @param host target Kuzzle host name or IP address
    * @param options the options
    * @throws URISyntaxException the uri syntax exception
    */
-  public Kuzzle(@NonNull final String url, KuzzleOptions options) throws URISyntaxException {
-    this(url, options, null);
+  public Kuzzle(@NonNull final String host, KuzzleOptions options) throws URISyntaxException {
+    this(host, options, null);
   }
 
   /**

--- a/src/main/java/io/kuzzle/sdk/core/KuzzleOptions.java
+++ b/src/main/java/io/kuzzle/sdk/core/KuzzleOptions.java
@@ -28,6 +28,7 @@ public class KuzzleOptions {
   private boolean replaceIfExist = false;
   private Long from;
   private Long size;
+  private Integer port = 7512;
 
   // Used for getting collections
   private KuzzleCollectionType  collectionType = KuzzleCollectionType.ALL;
@@ -386,5 +387,13 @@ public class KuzzleOptions {
 
   public void setSize(Long size) {
     this.size = size;
+  }
+
+  public void setPort(Integer port) {
+    this.port = port;
+  }
+
+  public Integer getPort() {
+    return this.port;
   }
 }

--- a/src/main/java/io/kuzzle/sdk/core/KuzzleOptions.java
+++ b/src/main/java/io/kuzzle/sdk/core/KuzzleOptions.java
@@ -32,9 +32,6 @@ public class KuzzleOptions {
   // Used for getting collections
   private KuzzleCollectionType  collectionType = KuzzleCollectionType.ALL;
 
-  // Used by Kuzzle security objects
-  private boolean hydrate = true;
-
   /**
    * Is auto reconnect boolean.
    *
@@ -313,26 +310,6 @@ public class KuzzleOptions {
   public KuzzleOptions setCollectionType(KuzzleCollectionType type) {
     this.collectionType = type;
     return this;
-  }
-
-  /**
-   * Sets hydrate.
-   *
-   * @param hydrate the hydrate
-   * @return the hydrate
-   */
-  public KuzzleOptions setHydrate(boolean hydrate) {
-    this.hydrate = hydrate;
-    return this;
-  }
-
-  /**
-   * Is hydrated boolean.
-   *
-   * @return the boolean
-   */
-  public boolean isHydrated() {
-    return this.hydrate;
   }
 
   /**

--- a/src/main/java/io/kuzzle/sdk/security/KuzzleProfile.java
+++ b/src/main/java/io/kuzzle/sdk/security/KuzzleProfile.java
@@ -6,8 +6,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.Arrays;
-
 import io.kuzzle.sdk.core.Kuzzle;
 import io.kuzzle.sdk.core.KuzzleOptions;
 import io.kuzzle.sdk.listeners.KuzzleResponseListener;
@@ -119,10 +117,11 @@ public class KuzzleProfile extends AbstractKuzzleSecurityDocument {
    * @return this kuzzle profile
    * @throws IllegalArgumentException, JSONException
    */
-  public KuzzleProfile addPolicy(final JSONObject policy) throws IllegalArgumentException, JSONException {
-    if (policy.getString("roleId") == null) {
+  public KuzzleProfile addPolicy(final JSONObject policy) throws IllegalArgumentException {
+    if (!policy.has("roleId")) {
       throw new IllegalArgumentException("The policy must have, at least, a roleId set.");
     }
+
     this.policies.put(policy);
     return this;
   }
@@ -134,9 +133,13 @@ public class KuzzleProfile extends AbstractKuzzleSecurityDocument {
    * @return this kuzzle profile
    * @throws JSONException the json exception
    */
-  public KuzzleProfile addPolicy(final String roleId) throws JSONException {
+  public KuzzleProfile addPolicy(final String roleId) {
     JSONObject policy = new JSONObject();
-    policy.put("roleId", roleId);
+    try {
+      policy.put("roleId", roleId);
+    } catch (JSONException e) {
+      throw new RuntimeException(e);
+    }
     this.policies.put(policy);
     return this;
   }
@@ -148,12 +151,17 @@ public class KuzzleProfile extends AbstractKuzzleSecurityDocument {
    * @return this roles
    * @throws IllegalArgumentException, JSONException
    */
-  public KuzzleProfile setPolicies(final JSONArray policies) throws IllegalArgumentException, JSONException {
-    for (int i = 0; i < policies.length(); i++) {
-      if (policies.getJSONObject(i).getString("roleId") == null) {
-        throw new IllegalArgumentException("All pocicies must have at least a roleId set.");
+  public KuzzleProfile setPolicies(final JSONArray policies) throws IllegalArgumentException {
+    try {
+      for (int i = 0; i < policies.length(); i++) {
+        if (!policies.getJSONObject(i).has("roleId")) {
+          throw new IllegalArgumentException("All pocicies must have at least a roleId set.");
+        }
       }
+    } catch (JSONException e) {
+      throw new RuntimeException(e);
     }
+
     this.policies = policies;
 
     return this;
@@ -166,11 +174,17 @@ public class KuzzleProfile extends AbstractKuzzleSecurityDocument {
    * @return this roles
    * @throws JSONException
    */
-  public KuzzleProfile setPolicies(final String rolesIds[]) throws JSONException {
-    for (int i = 0; i < rolesIds.length; i++) {
-      JSONObject policy = new JSONObject();
-      policy.put("roleId", rolesIds[i]);
-      this.policies.put(policy);
+  public KuzzleProfile setPolicies(final String rolesIds[]) {
+    try {
+      for (int i = 0; i < rolesIds.length; i++) {
+        JSONObject policy = new JSONObject();
+
+        policy.put("roleId", rolesIds[i]);
+
+        this.policies.put(policy);
+      }
+    } catch (JSONException e) {
+      throw new RuntimeException(e);
     }
 
     return this;

--- a/src/main/java/io/kuzzle/sdk/security/KuzzleProfile.java
+++ b/src/main/java/io/kuzzle/sdk/security/KuzzleProfile.java
@@ -6,7 +6,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.ArrayDeque;
 import java.util.Arrays;
 
 import io.kuzzle.sdk.core.Kuzzle;
@@ -18,7 +17,7 @@ import io.kuzzle.sdk.listeners.OnQueryDoneListener;
  * This class handles profiles management in Kuzzle
  */
 public class KuzzleProfile extends AbstractKuzzleSecurityDocument {
-  private ArrayDeque<KuzzleRole> roles;
+  private JSONArray policies = new JSONArray();
 
   /**
    * Instantiates a new Kuzzle profile.
@@ -32,28 +31,14 @@ public class KuzzleProfile extends AbstractKuzzleSecurityDocument {
     super(kuzzle, id, null);
     this.deleteActionName = "deleteProfile";
     this.updateActionName = "updateProfile";
-    this.roles = new ArrayDeque<>();
 
     if (content != null) {
       this.content = new JSONObject(content.toString());
 
-      if (content.has("roles")) {
-        JSONArray roles = content.getJSONArray("roles");
-        int rolesLength = roles.length();
+      if (content.has("policies")) {
+        this.policies = content.getJSONArray("policies");
 
-        this.content.remove("roles");
-
-        for (int i = 0; i < rolesLength; i++) {
-          JSONObject role = roles.getJSONObject(i);
-
-          if (role.has("_id")) {
-            if (role.has("_source")) {
-              this.roles.add(new KuzzleRole(this.kuzzle, role.getString("_id"), role.getJSONObject("_source")));
-            } else {
-              this.roles.add(new KuzzleRole(this.kuzzle, role.getString("_id"), role));
-            }
-          }
-        }
+        this.content.remove("policies");
       }
     }
   }
@@ -69,8 +54,8 @@ public class KuzzleProfile extends AbstractKuzzleSecurityDocument {
   public KuzzleProfile save(final KuzzleOptions options, final KuzzleResponseListener<KuzzleProfile> listener) throws JSONException {
     JSONObject data;
 
-    if (this.roles.isEmpty()) {
-      throw new IllegalArgumentException("Cannot save the profile " + this.id + ": no role defined");
+    if (this.policies.length() == 0) {
+      throw new IllegalArgumentException("Cannot save the profile " + this.id + ": no policies defined");
     }
 
     data = this.serialize();
@@ -130,116 +115,65 @@ public class KuzzleProfile extends AbstractKuzzleSecurityDocument {
   /**
    * Add a new role to the list of allowed roles of this profile
    *
-   * @param role - Role to add to this profile
+   * @param policy - Policy to add to this profile
    * @return this kuzzle profile
+   * @throws IllegalArgumentException, JSONException
    */
-  public KuzzleProfile addRole(final KuzzleRole role) {
-    this.roles.add(role);
+  public KuzzleProfile addPolicy(final JSONObject policy) throws IllegalArgumentException, JSONException {
+    if (policy.getString("roleId") == null) {
+      throw new IllegalArgumentException("The policy must have, at least, a roleId set.");
+    }
+    this.policies.put(policy);
     return this;
   }
 
   /**
-   * Add a new role to the list of allowed roles of this profile
+   * Add a new policy to the list of policies of this profile via its roleId
    *
-   * @param role - Name of the role to add to this profile
+   * @param  roleId - Name of the role to add to this profile
    * @return this kuzzle profile
    * @throws JSONException the json exception
    */
-  public KuzzleProfile addRole(final String role) throws JSONException {
-    this.roles.add(new KuzzleRole(this.kuzzle, role, null));
+  public KuzzleProfile addPolicy(final String roleId) throws JSONException {
+    JSONObject policy = new JSONObject();
+    policy.put("roleId", roleId);
+    this.policies.put(policy);
     return this;
   }
 
   /**
-   * Replace the current roles list with a new one
+   * Replace the current policies list with a new one
    *
-   * @param roles - New roles list
+   * @param policies - New policies list
    * @return this roles
+   * @throws IllegalArgumentException, JSONException
    */
-  public KuzzleProfile setRoles(final KuzzleRole roles[]) {
-    this.roles.clear();
-    this.roles.addAll(Arrays.asList(roles));
+  public KuzzleProfile setPolicies(final JSONArray policies) throws IllegalArgumentException, JSONException {
+    for (int i = 0; i < policies.length(); i++) {
+      if (policies.getJSONObject(i).getString("roleId") == null) {
+        throw new IllegalArgumentException("All pocicies must have at least a roleId set.");
+      }
+    }
+    this.policies = policies;
 
     return this;
   }
 
   /**
-   * Replace the current roles list with a new one
+   * Replace the current policies list with a new one via its rolesIds
    *
-   * @param roles - New roles list
+   * @param rolesIds - New roles list
    * @return this roles
+   * @throws JSONException
    */
-  public KuzzleProfile setRoles(final String roles[]) {
-    this.roles.clear();
-    for(String role : roles) {
-      try {
-        this.roles.add(new KuzzleRole(this.kuzzle, role, null));
-      }
-      catch(JSONException e) {
-        throw new RuntimeException(e);
-      }
+  public KuzzleProfile setPolicies(final String rolesIds[]) throws JSONException {
+    for (int i = 0; i < rolesIds.length; i++) {
+      JSONObject policy = new JSONObject();
+      policy.put("roleId", rolesIds[i]);
+      this.policies.put(policy);
     }
 
     return this;
-  }
-
-  /**
-   * Hydrate the profile - get real KuzzleRole and not just ids
-   * Trying to hydrate when new unsaved roles have been added will fail
-   *
-   * @param options  - Optional arguments
-   * @param listener - Callback listener
-   * @throws JSONException the json exception
-   */
-  public void hydrate(final KuzzleOptions options, @NonNull final KuzzleResponseListener<KuzzleProfile> listener) throws JSONException {
-    if (listener == null) {
-      throw new IllegalArgumentException("KuzzleRole.hydrate: a callback listener is required");
-    }
-
-    JSONArray ids = new JSONArray();
-
-    for(KuzzleRole role : this.roles) {
-      ids.put(role.id);
-    }
-
-    JSONObject data = new JSONObject().put("body", ids);
-
-    this.kuzzle.query(this.kuzzleSecurity.buildQueryArgs("mGetRoles"), data, options, new OnQueryDoneListener() {
-      @Override
-      public void onSuccess(JSONObject response) {
-        try {
-          JSONObject result = response.getJSONObject("result");
-          JSONArray hits = result.getJSONArray("hits");
-          KuzzleProfile profile = new KuzzleProfile(KuzzleProfile.this.kuzzle, KuzzleProfile.this.id, null);
-
-          for (int i = 0; i < hits.length(); i++) {
-            JSONObject role = hits.getJSONObject(i);
-            profile.addRole(new KuzzleRole(KuzzleProfile.this.kuzzle, role.getString("_id"), role.getJSONObject("_source")));
-          }
-
-          listener.onSuccess(profile);
-        }
-        catch (JSONException e) {
-          throw new RuntimeException(e);
-        }
-      }
-
-      @Override
-      public void onError(JSONObject error) {
-        listener.onError(error);
-      }
-    });
-  }
-
-  /**
-   * Hydrate the profile - get real KuzzleRole and not just ids
-   * Trying to hydrate when new unsaved roles have been added will fail
-   *
-   * @param listener - Callback listener
-   * @throws JSONException the json exception
-   */
-  public void hydrate(@NonNull final KuzzleResponseListener<KuzzleProfile> listener) throws JSONException {
-    hydrate(null, listener);
   }
 
   /**
@@ -252,14 +186,8 @@ public class KuzzleProfile extends AbstractKuzzleSecurityDocument {
       data = new JSONObject(),
       content = new JSONObject(this.content.toString());
 
-    if (!this.roles.isEmpty()) {
-      JSONArray roles = new JSONArray();
-
-      for (KuzzleRole role : this.roles) {
-        roles.put(role.id);
-      }
-
-      content.put("roles", roles);
+    if (this.policies.length() > 0) {
+      content.put("policies", this.policies);
     }
 
     data
@@ -270,11 +198,11 @@ public class KuzzleProfile extends AbstractKuzzleSecurityDocument {
   }
 
   /**
-   * Return the list of roles assigned to this profile
+   * Return the list of the policies assigned to this profile
    *
-   * @return an array of KuzzleRole objects
+   * @return a JSONArray of policies" objects
    */
-  public KuzzleRole[] getRoles() {
-    return this.roles.toArray(new KuzzleRole[this.roles.size()]);
+  public JSONArray getPolicies() {
+    return this.policies;
   }
 }

--- a/src/main/java/io/kuzzle/sdk/security/KuzzleSecurity.java
+++ b/src/main/java/io/kuzzle/sdk/security/KuzzleSecurity.java
@@ -465,20 +465,23 @@ public class KuzzleSecurity {
           JSONObject result = response.getJSONObject("result");
           JSONArray formattedPolicies = new JSONArray();
           JSONArray policies = result.getJSONObject("_source").getJSONArray("policies");
+
           for (int i = 0; i < policies.length(); i++) {
             JSONObject formattedPolicy = new JSONObject()
-                .put("roleId", ((JSONObject)policies.get(i)).getString("roleId"));
+                .put("roleId", policies.getJSONObject(i).getString("roleId"));
             if (((JSONObject) policies.get(i)).has("restrictedTo")) {
-              formattedPolicy.put("restrictedTo", ((JSONObject) policies.get(i)).getJSONArray("restrictedTo"));
+              formattedPolicy.put("restrictedTo", policies.getJSONObject(i).getJSONArray("restrictedTo"));
             }
             if (((JSONObject) policies.get(i)).has("allowInternalIndex")) {
-              formattedPolicy.put("allowInternalIndex", ((JSONObject) policies.get(i)).getBoolean("allowInternalIndex"));
+              formattedPolicy.put("allowInternalIndex", policies.getJSONObject(i).getBoolean("allowInternalIndex"));
             }
             formattedPolicies.put(formattedPolicy);
           }
+
           result.getJSONObject("_source").remove("policies");
           result.getJSONObject("_source").put("policies", formattedPolicies);
-          listener.onSuccess(new KuzzleProfile(KuzzleSecurity.this.kuzzle, result.getString("roleId"), result.getJSONObject("_source")));
+
+          listener.onSuccess(new KuzzleProfile(KuzzleSecurity.this.kuzzle, result.getString("_id"), result.getJSONObject("_source")));
         } catch (JSONException e) {
           throw new RuntimeException(e);
         }

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/checkTokenTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/checkTokenTest.java
@@ -38,7 +38,7 @@ public class checkTokenTest {
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");
 
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(mock(Socket.class));
 
     listener = new KuzzleResponseListener<Object>() {

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/connectionManagementTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/connectionManagementTest.java
@@ -66,7 +66,7 @@ public class connectionManagementTest {
 
       }
     };
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, listener);
+    kuzzle = new KuzzleExtend("localhost", options, listener);
     kuzzle.setSocket(s);
   }
 
@@ -86,7 +86,7 @@ public class connectionManagementTest {
     JSONObject query = new JSONObject("{\"controller\":\"test3\",\"metadata\":{},\"requestId\":\"a476ae61-497e-4338-b4dd-751ac22c6b61\",\"action\":\"test3\",\"collection\":\"test3\"}");
     o.setQuery(query);
 
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(s);
 
     doAnswer(new Answer() {
@@ -122,7 +122,7 @@ public class connectionManagementTest {
     options.setConnect(Mode.MANUAL);
     options.setAutoReconnect(true);
     options.setOfflineMode(Mode.AUTO);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", options, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", options, null);
     extended.setSocket(s);
     extended.setState(KuzzleStates.INITIALIZING);
     final Kuzzle kuzzleSpy = spy(extended);
@@ -175,7 +175,7 @@ public class connectionManagementTest {
       }
     }).when(s).once(eq(Socket.EVENT_DISCONNECT), any(Emitter.Listener.class));
 
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(s);
     kuzzle = spy(kuzzle);
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/constructorTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/constructorTest.java
@@ -40,7 +40,7 @@ public class constructorTest {
     options.setDefaultIndex("testIndex");
 
     s = mock(Socket.class);
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(s);
 
     listener = new KuzzleResponseListener<Object>() {
@@ -63,11 +63,11 @@ public class constructorTest {
 
   @Test
   public void checkSignaturesVariants() throws URISyntaxException {
-    Kuzzle k = new Kuzzle("http://localhost:7512");
+    Kuzzle k = new Kuzzle("localhost");
     assertNotNull(k);
-    k = new Kuzzle("http://localhost:7512", new KuzzleOptions());
+    k = new Kuzzle("localhost", new KuzzleOptions());
     assertNotNull(k);
-    k = new Kuzzle("http://localhost:7512", listener);
+    k = new Kuzzle("localhost", listener);
     assertNotNull(k);
   }
 
@@ -120,7 +120,7 @@ public class constructorTest {
     KuzzleOptions options = new KuzzleOptions();
     options.setQueuable(false);
     options.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", options, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", options, null);
     extended.setSocket(s);
     extended.setState(KuzzleStates.CONNECTED);
 
@@ -147,7 +147,7 @@ public class constructorTest {
     options.setMetadata(meta);
     options.setQueuable(false);
     options.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", options, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", options, null);
     extended.setSocket(s);
     extended.setState(KuzzleStates.CONNECTED);
     extended.query(QueryArgsHelper.makeQueryArgs("controller", "action"), jsonObj, options);

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/eventSystemTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/eventSystemTest.java
@@ -43,7 +43,7 @@ public class eventSystemTest {
     options.setDefaultIndex("testIndex");
 
     s = mock(Socket.class);
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(s);
 
     listener = new KuzzleResponseListener<Object>() {

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/factoriesTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/factoriesTest.java
@@ -27,7 +27,7 @@ public class factoriesTest {
     options.setDefaultIndex("testIndex");
 
     s = mock(Socket.class);
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(s);
 
     listener = new KuzzleResponseListener<Object>() {

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/getAllStatisticsTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/getAllStatisticsTest.java
@@ -41,7 +41,7 @@ public class getAllStatisticsTest {
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");
 
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(mock(Socket.class));
 
     listener = new KuzzleResponseListener<Object>() {

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/getAutoRefreshTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/getAutoRefreshTest.java
@@ -40,7 +40,7 @@ public class getAutoRefreshTest {
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");
 
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(mock(Socket.class));
 
     listener = mock(KuzzleResponseListener.class);

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/getLastStatisticsTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/getLastStatisticsTest.java
@@ -37,7 +37,7 @@ public class getLastStatisticsTest {
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");
 
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(mock(Socket.class));
 
     listener = new KuzzleResponseListener<Object>() {

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/getMyRightsTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/getMyRightsTest.java
@@ -32,7 +32,7 @@ public class getMyRightsTest {
 
   @Before
   public void setUp() throws URISyntaxException {
-    kuzzle = spy(new KuzzleExtend("http://localhost:7512", mock(KuzzleOptions.class), mock(KuzzleResponseListener.class)));
+    kuzzle = spy(new KuzzleExtend("localhost", mock(KuzzleOptions.class), mock(KuzzleResponseListener.class)));
     listener = mock(KuzzleResponseListener.class);
   }
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/getServerInfoTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/getServerInfoTest.java
@@ -37,7 +37,7 @@ public class getServerInfoTest {
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");
 
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(mock(Socket.class));
 
     listener = new KuzzleResponseListener<Object>() {

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/getStatisticsTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/getStatisticsTest.java
@@ -40,7 +40,7 @@ public class getStatisticsTest {
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");
 
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(mock(Socket.class));
 
     listener = new KuzzleResponseListener<Object>() {

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/kuzzleWebViewTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/kuzzleWebViewTest.java
@@ -32,7 +32,7 @@ public class kuzzleWebViewTest {
     options.setDefaultIndex("testIndex");
 
     s = mock(Socket.class);
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(s);
     webViewClient = kuzzle.getKuzzleWebViewClient();
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/listCollectionsTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/listCollectionsTest.java
@@ -37,7 +37,7 @@ public class listCollectionsTest {
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");
 
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(mock(Socket.class));
 
     listener = new KuzzleResponseListener<Object>() {

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/listIndexesTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/listIndexesTest.java
@@ -38,7 +38,7 @@ public class listIndexesTest {
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");
 
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(mock(Socket.class));
 
     listener = new KuzzleResponseListener<Object>() {

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/loginTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/loginTest.java
@@ -41,7 +41,7 @@ public class loginTest {
     options.setDefaultIndex("testIndex");
 
     s = mock(Socket.class);
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(s);
 
     listener = new KuzzleResponseListener<Object>() {

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/logoutTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/logoutTest.java
@@ -40,7 +40,7 @@ public class logoutTest {
     options.setDefaultIndex("testIndex");
 
     s = mock(Socket.class);
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(s);
 
     listener = new KuzzleResponseListener<Object>() {

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/nowTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/nowTest.java
@@ -39,7 +39,7 @@ public class nowTest {
     options.setDefaultIndex("testIndex");
 
     s = mock(Socket.class);
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(s);
 
     listener = new KuzzleResponseListener<Object>() {

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/offlineQueueLoaderTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/offlineQueueLoaderTest.java
@@ -41,7 +41,7 @@ public class offlineQueueLoaderTest {
     KuzzleOptions options = new KuzzleOptions();
     options.setConnect(Mode.MANUAL);
     s = mock(Socket.class);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", options, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", options, null);
     extended.setSocket(s);
     kuzzleExtend = extended;
   }

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/queryTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/queryTest.java
@@ -45,7 +45,7 @@ public class queryTest {
     KuzzleOptions options = new KuzzleOptions();
     options.setConnect(Mode.MANUAL);
 
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setState(KuzzleStates.CONNECTED);
     kuzzle.setSocket(socket);
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/queueManagementTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/queueManagementTest.java
@@ -42,7 +42,7 @@ public class queueManagementTest {
     options.setDefaultIndex("testIndex");
 
     s = mock(Socket.class);
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(s);
 
     listener = new KuzzleResponseListener<Object>() {
@@ -67,7 +67,7 @@ public class queueManagementTest {
     options.setAutoReconnect(true);
     options.setOfflineMode(Mode.AUTO);
 
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     KuzzleQueryObject o = new KuzzleQueryObject();
     o.setTimestamp(new Date());
     o.setAction("test");
@@ -89,7 +89,7 @@ public class queueManagementTest {
     options.setQueueTTL(10000);
     options.setReplayInterval(1);
     options.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", options, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", options, null);
     extended.setSocket(s);
     extended.setState(KuzzleStates.CONNECTED);
 
@@ -125,7 +125,7 @@ public class queueManagementTest {
     KuzzleOptions options = new KuzzleOptions();
     options.setAutoReconnect(false);
     options.setDefaultIndex("testIndex");
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.connect();
     kuzzle.listCollections(mock(KuzzleResponseListener.class));
     assertEquals(kuzzle.getOfflineQueue().size(), 1);
@@ -145,7 +145,7 @@ public class queueManagementTest {
     options.setAutoReplay(true);
     options.setConnect(Mode.MANUAL);
     options.setOfflineMode(Mode.AUTO);
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(s);
 
     doAnswer(new Answer() {
@@ -174,7 +174,7 @@ public class queueManagementTest {
     options.setReplayInterval(1);
     options.setConnect(Mode.MANUAL);
     options.setOfflineMode(Mode.AUTO);
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(s);
 
     doAnswer(new Answer() {

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/refreshIndexTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/refreshIndexTest.java
@@ -40,7 +40,7 @@ public class refreshIndexTest {
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");
 
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(mock(Socket.class));
 
     listener = mock(KuzzleResponseListener.class);

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/setAutoRefreshTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/setAutoRefreshTest.java
@@ -39,7 +39,7 @@ public class setAutoRefreshTest {
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");
 
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(mock(Socket.class));
 
     listener = mock(KuzzleResponseListener.class);

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/setJwtTokenTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/setJwtTokenTest.java
@@ -38,7 +38,7 @@ public class setJwtTokenTest {
     options.setDefaultIndex("testIndex");
 
     s = mock(Socket.class);
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(s);
 
     kuzzle = spy(kuzzle);

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/subscriptionsManagementTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/subscriptionsManagementTest.java
@@ -32,7 +32,7 @@ public class subscriptionsManagementTest {
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");
 
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(mock(Socket.class));
 
     listener = new KuzzleResponseListener<Object>() {

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/updateSelfTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/updateSelfTest.java
@@ -32,7 +32,7 @@ public class updateSelfTest {
 
   @Before
   public void setUp() throws URISyntaxException {
-    kuzzle = spy(new Kuzzle("http://localhost:7512"));
+    kuzzle = spy(new Kuzzle("localhost"));
     argument = ArgumentCaptor.forClass(Kuzzle.QueryArgs.class);
     listener = spy(new KuzzleResponseListener<JSONObject>() {
       @Override

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/whoAmiTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/whoAmiTest.java
@@ -37,7 +37,7 @@ public class whoAmiTest {
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");
 
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(mock(Socket.class));
 
     listener = new KuzzleResponseListener<Object>() {

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/advancedSearchTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/advancedSearchTest.java
@@ -41,7 +41,7 @@ public class advancedSearchTest {
   public void setUp() throws URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
     kuzzle = spy(extended);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/constructorTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/constructorTest.java
@@ -35,7 +35,7 @@ public class constructorTest {
   public void setUp() throws URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/countTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/countTest.java
@@ -40,7 +40,7 @@ public class countTest {
   public void setUp() throws URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/createDocumentTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/createDocumentTest.java
@@ -40,7 +40,7 @@ public class createDocumentTest {
   public void setUp() throws URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/createTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/createTest.java
@@ -39,7 +39,7 @@ public class createTest {
   public void setUp() throws URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/deleteDocumentTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/deleteDocumentTest.java
@@ -40,7 +40,7 @@ public class deleteDocumentTest {
   public void setUp() throws URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/factoriesTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/factoriesTest.java
@@ -38,7 +38,7 @@ public class factoriesTest {
   public void setUp() throws URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/fetchAllDocumentsTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/fetchAllDocumentsTest.java
@@ -36,7 +36,7 @@ public class fetchAllDocumentsTest {
   public void setUp() throws URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/fetchDocument.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/fetchDocument.java
@@ -40,7 +40,7 @@ public class fetchDocument {
   public void setUp() throws URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/getMappingTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/getMappingTest.java
@@ -36,7 +36,7 @@ public class getMappingTest {
   public void setUp() throws URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
     kuzzle = spy(extended);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/publishMessageTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/publishMessageTest.java
@@ -37,7 +37,7 @@ public class publishMessageTest {
   public void setUp() throws URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/replaceDocumentTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/replaceDocumentTest.java
@@ -40,7 +40,7 @@ public class replaceDocumentTest {
   public void setUp() throws URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/subscribeTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/subscribeTest.java
@@ -37,7 +37,7 @@ public class subscribeTest {
   public void setUp() throws URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/truncateTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/truncateTest.java
@@ -39,7 +39,7 @@ public class truncateTest {
   public void setUp() throws URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/updateDocumentTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/updateDocumentTest.java
@@ -39,7 +39,7 @@ public class updateDocumentTest {
   public void setUp() throws URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDocument/constructorTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDocument/constructorTest.java
@@ -35,7 +35,7 @@ public class constructorTest {
   public void setUp() throws URISyntaxException, JSONException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setState(KuzzleStates.CONNECTED);
     k = spy(extended);
     doc = new KuzzleDocument(new KuzzleDataCollection(k, "index", "test"));

--- a/src/test/java/io/kuzzle/test/core/KuzzleDocument/deleteTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDocument/deleteTest.java
@@ -38,7 +38,7 @@ public class deleteTest {
   public void setUp() throws URISyntaxException, JSONException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setState(KuzzleStates.CONNECTED);
     k = spy(extended);
     doc = new KuzzleDocument(new KuzzleDataCollection(k, "index", "test"));

--- a/src/test/java/io/kuzzle/test/core/KuzzleDocument/publishTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDocument/publishTest.java
@@ -33,7 +33,7 @@ public class publishTest {
   public void setUp() throws URISyntaxException, JSONException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setState(KuzzleStates.CONNECTED);
     k = spy(extended);
     doc = new KuzzleDocument(new KuzzleDataCollection(k, "index", "test"));

--- a/src/test/java/io/kuzzle/test/core/KuzzleDocument/refreshTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDocument/refreshTest.java
@@ -40,7 +40,7 @@ public class refreshTest {
   public void setUp() throws URISyntaxException, JSONException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setState(KuzzleStates.CONNECTED);
     k = spy(extended);
     mockListener = mock(KuzzleResponseListener.class);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDocument/saveTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDocument/saveTest.java
@@ -38,7 +38,7 @@ public class saveTest {
   public void setUp() throws URISyntaxException, JSONException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setState(KuzzleStates.CONNECTED);
     k = spy(extended);
     mockListener = mock(KuzzleResponseListener.class);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDocument/serializeTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDocument/serializeTest.java
@@ -29,7 +29,7 @@ public class serializeTest {
   public void setUp() throws URISyntaxException, JSONException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setState(KuzzleStates.CONNECTED);
     k = spy(extended);
     doc = new KuzzleDocument(new KuzzleDataCollection(k, "index", "test"));

--- a/src/test/java/io/kuzzle/test/core/KuzzleDocument/subscribeTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDocument/subscribeTest.java
@@ -37,7 +37,7 @@ public class subscribeTest {
   public void setUp() throws URISyntaxException, JSONException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setState(KuzzleStates.CONNECTED);
     k = spy(extended);
     mockCollection = mock(KuzzleDataCollection.class);

--- a/src/test/java/io/kuzzle/test/core/KuzzleRoom/countTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleRoom/countTest.java
@@ -62,7 +62,7 @@ public class countTest {
         .put("result", new JSONObject())
         .put("requestId", "42");
     mockResponse.put("result", new JSONObject().put("channel", "channel").put("roomId", "42"));
-    k = spy(new KuzzleExtend("http://localhost:7512", null, null));
+    k = spy(new KuzzleExtend("localhost", null, null));
     k.setSocket(mock(Socket.class));
     k.setState(KuzzleStates.CONNECTED);
     when(k.getHeaders()).thenReturn(new JSONObject());
@@ -78,7 +78,7 @@ public class countTest {
   public void testCountWhileSubscribing() throws JSONException, URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
     extended = spy(extended);
@@ -140,7 +140,7 @@ public class countTest {
     JSONObject o = mock(JSONObject.class);
     when(o.put(any(String.class), any(Object.class))).thenReturn(new JSONObject());
 
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", null, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", null, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
     extended = spy(extended);

--- a/src/test/java/io/kuzzle/test/core/KuzzleRoom/notificationHandlerTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleRoom/notificationHandlerTest.java
@@ -94,7 +94,7 @@ public class notificationHandlerTest {
     options.setSubscribeToSelf(true);
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     Socket s = mock(Socket.class);
     extended.setSocket(s);
     extended.setState(KuzzleStates.CONNECTED);
@@ -110,7 +110,7 @@ public class notificationHandlerTest {
   public void testRenewOn() throws JSONException, URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     Socket s = mock(Socket.class);
     extended.setSocket(s);
     extended.setState(KuzzleStates.CONNECTED);
@@ -144,7 +144,7 @@ public class notificationHandlerTest {
 
   @Test
   public void testJwtTokenExpiredNotification() throws JSONException, URISyntaxException {
-    k = new Kuzzle("http://localhost:7512");
+    k = new Kuzzle("localhost");
     IKuzzleEventListener listener = spy(new IKuzzleEventListener() {
       @Override
       public void trigger(Object... args) {
@@ -166,7 +166,7 @@ public class notificationHandlerTest {
     KuzzleRoomOptions options = new KuzzleRoomOptions();
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     Socket s = mock(Socket.class);
     extended.setSocket(s);
     extended.setState(KuzzleStates.CONNECTED);

--- a/src/test/java/io/kuzzle/test/core/KuzzleRoom/renewTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleRoom/renewTest.java
@@ -69,7 +69,7 @@ public class renewTest {
     KuzzleOptions options = new KuzzleOptions();
     options.setConnect(Mode.MANUAL);
     Socket s = mock(Socket.class);
-    KuzzleExtend kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    KuzzleExtend kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setState(KuzzleStates.CONNECTED);
 
     final Kuzzle kuzzleSpy = spy(kuzzle);
@@ -107,7 +107,7 @@ public class renewTest {
   public void testRenewQueryException() throws JSONException, URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
     extended = spy(extended);
@@ -122,7 +122,7 @@ public class renewTest {
   public void testRenewException() throws JSONException, URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
     extended = spy(extended);
@@ -149,7 +149,7 @@ public class renewTest {
   public void testNoRenewal() throws JSONException, URISyntaxException {
     KuzzleOptions options = new KuzzleOptions();
     options.setConnect(Mode.MANUAL);
-    KuzzleExtend kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    KuzzleExtend kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setState(KuzzleStates.CONNECTED);
     kuzzle.setSocket(mock(Socket.class));
 
@@ -177,7 +177,7 @@ public class renewTest {
   public void testRenewWhileSubscribing() throws JSONException, URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
     extended = spy(extended);

--- a/src/test/java/io/kuzzle/test/core/KuzzleRoom/unsubscribeTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleRoom/unsubscribeTest.java
@@ -67,7 +67,7 @@ public class unsubscribeTest {
     opts.setConnect(Mode.MANUAL);
     Socket s = mock(Socket.class);
 
-    KuzzleExtend kuzzle = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend kuzzle = new KuzzleExtend("localhost", opts, null);
     kuzzle.setState(KuzzleStates.CONNECTED);
     kuzzle.setSocket(s);
 
@@ -86,7 +86,7 @@ public class unsubscribeTest {
   public void testUnsubscribeWhileSubscribing() throws JSONException, URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
     extended = spy(extended);
@@ -122,7 +122,7 @@ public class unsubscribeTest {
     opts.setConnect(Mode.MANUAL);
     Socket s = mock(Socket.class);
 
-    KuzzleExtend kuzzle = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend kuzzle = new KuzzleExtend("localhost", opts, null);
     kuzzle.setState(KuzzleStates.CONNECTED);
     kuzzle.setSocket(s);
 
@@ -141,7 +141,7 @@ public class unsubscribeTest {
   public void testUnsubscribeException() throws URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
     extended = spy(extended);
@@ -155,7 +155,7 @@ public class unsubscribeTest {
   public void testUnsubscribeTask() throws URISyntaxException, JSONException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
     extended = spy(extended);
@@ -170,7 +170,7 @@ public class unsubscribeTest {
   public void testUnsubscribeTaskException() throws URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
     extended = spy(extended);

--- a/src/test/java/io/kuzzle/test/listeners/KuzzleListenerTest.java
+++ b/src/test/java/io/kuzzle/test/listeners/KuzzleListenerTest.java
@@ -41,7 +41,7 @@ public class KuzzleListenerTest {
     KuzzleOptions options = new KuzzleOptions();
     options.setConnect(Mode.MANUAL);
     s = mock(Socket.class);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", options, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", options, null);
     extended.setSocket(s);
     kuzzle = extended;
     kuzzleExtend = extended;

--- a/src/test/java/io/kuzzle/test/security/KuzzleProfileTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleProfileTest.java
@@ -22,7 +22,9 @@ import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -88,6 +90,12 @@ public class KuzzleProfileTest {
     stubProfile.addPolicy(new JSONObject().put("roleId", "some role"));
     assertEquals(stubProfile.getPolicies().length(), 1);
     assertTrue(stubProfile.getPolicies().getJSONObject(0).getString("roleId") == "some role");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testAddNullPolicyObject() throws JSONException {
+    stubProfile.addPolicy(new JSONObject().put("roleId", null));
+    doThrow(IllegalArgumentException.class).when(stubProfile).addPolicy(any(JSONObject.class));
   }
 
   @Test

--- a/src/test/java/io/kuzzle/test/security/KuzzleProfileTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleProfileTest.java
@@ -1,5 +1,6 @@
 package io.kuzzle.test.security;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -16,6 +17,7 @@ import io.kuzzle.sdk.security.KuzzleProfile;
 import io.kuzzle.sdk.security.KuzzleRole;
 import io.kuzzle.sdk.security.KuzzleSecurity;
 
+import static junit.framework.Assert.assertTrue;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -42,7 +44,7 @@ public class KuzzleProfileTest {
   public void testConstructorNoContent() throws JSONException {
     KuzzleProfile profile = new KuzzleProfile(kuzzle, "foo", null);
     assertEquals(profile.id, "foo");
-    assertEquals(profile.getRoles().length, 0);
+    assertEquals(profile.getPolicies().length(), 0);
     assertThat(profile.content, instanceOf(JSONObject.class));
     assertEquals(profile.content.length(), 0);
   }
@@ -51,13 +53,13 @@ public class KuzzleProfileTest {
   public void testConstructorContentWithIDs() throws JSONException {
     JSONObject content = new JSONObject(
       "{" +
-        "\"roles\": [{\"_id\": \"foo\"}, {\"_id\": \"bar\"}, {\"_id\": \"baz\"}]" +
+        "\"policies\": [{\"roleId\": \"foo\"}, {\"roleId\": \"bar\"}, {\"roleId\": \"baz\"}]" +
       "}"
     );
     KuzzleProfile profile = new KuzzleProfile(kuzzle, "foo", content);
     assertEquals(profile.id, "foo");
-    assertEquals(profile.getRoles().length, 3);
-    assertEquals(profile.getRoles()[2].id, "baz");
+    assertEquals(profile.getPolicies().length(), 3);
+    assertEquals(profile.getPolicies().getJSONObject(2).getString("roleId"), "baz");
     assertThat(profile.content, instanceOf(JSONObject.class));
     assertEquals(profile.content.length(), 0);
   }
@@ -66,33 +68,33 @@ public class KuzzleProfileTest {
   public void testConstructorContentWithRoles() throws JSONException {
     JSONObject content = new JSONObject(
       "{" +
-        "\"roles\": [" +
-          "{\"_id\": \"foo\", \"_source\": {}}, " +
-          "{\"_id\": \"bar\", \"_source\": {}}, " +
-          "{\"_id\": \"baz\", \"_source\": {}}" +
+        "\"policies\": [" +
+          "{\"roleId\": \"foo\"}, " +
+          "{\"roleId\": \"bar\"}, " +
+          "{\"roleId\": \"baz\"}" +
         "]" +
       "}"
     );
     KuzzleProfile profile = new KuzzleProfile(kuzzle, "foo", content);
     assertEquals(profile.id, "foo");
-    assertEquals(profile.getRoles().length, 3);
-    assertEquals(profile.getRoles()[2].id, "baz");
+    assertEquals(profile.getPolicies().length(), 3);
+    assertEquals(profile.getPolicies().getJSONObject(2).getString("roleId"), "baz");
     assertThat(profile.content, instanceOf(JSONObject.class));
     assertEquals(profile.content.length(), 0);
   }
 
   @Test
-  public void testAddRoleObject() throws JSONException {
-    stubProfile.addRole(new KuzzleRole(kuzzle, "some role", null));
-    assertEquals(stubProfile.getRoles().length, 1);
-    assertEquals(stubProfile.getRoles()[0].id, "some role");
+  public void testAddPolicyObject() throws JSONException {
+    stubProfile.addPolicy(new JSONObject().put("roleId", "some role"));
+    assertEquals(stubProfile.getPolicies().length(), 1);
+    assertTrue(stubProfile.getPolicies().getJSONObject(0).getString("roleId") == "some role");
   }
 
   @Test
-  public void testAddRoleID() throws JSONException {
-    stubProfile.addRole("another role");
-    assertEquals(stubProfile.getRoles().length, 1);
-    assertEquals(stubProfile.getRoles()[0].id, "another role");
+  public void testAddPolicyID() throws JSONException {
+    stubProfile.addPolicy("another role");
+    assertEquals(stubProfile.getPolicies().length(), 1);
+    assertTrue(stubProfile.getPolicies().getJSONObject(0).getString("roleId") == "another role");
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -102,7 +104,7 @@ public class KuzzleProfileTest {
 
   @Test
   public void testSaveNoListener() throws JSONException {
-    stubProfile.addRole("baz");
+    stubProfile.addPolicy("baz");
     stubProfile.save();
     ArgumentCaptor argument = ArgumentCaptor.forClass(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class);
     verify(kuzzle, times(1)).query((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.capture(), any(JSONObject.class), any(KuzzleOptions.class));
@@ -121,7 +123,7 @@ public class KuzzleProfileTest {
       }
     }).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
 
-    stubProfile.addRole("baz");
+    stubProfile.addPolicy("baz");
     stubProfile.save(new KuzzleResponseListener<KuzzleProfile>() {
       @Override
       public void onSuccess(KuzzleProfile response) {
@@ -147,111 +149,27 @@ public class KuzzleProfileTest {
   }
 
   @Test
-  public void testSetRolesObjectList() throws JSONException {
-    KuzzleRole[] roles = {
-      new KuzzleRole(kuzzle, "bar", null),
-      new KuzzleRole(kuzzle, "baz", null),
-      new KuzzleRole(kuzzle, "qux", null)
-    };
+  public void testSetPoliciesObjectList() throws JSONException {
+    JSONArray policies = new JSONArray("[{\"roleId\": \"bar\"},{\"roleId\": \"baz\"},{\"roleId\": \"qux\"}]");
 
-    stubProfile.addRole("foo");
-    stubProfile.setRoles(roles);
-    assertEquals(stubProfile.getRoles().length, 3);
-    assertEquals(stubProfile.getRoles()[0].id, "bar");
-    assertEquals(stubProfile.getRoles()[1].id, "baz");
-    assertEquals(stubProfile.getRoles()[2].id, "qux");
+    stubProfile.addPolicy("foo");
+    stubProfile.setPolicies(policies);
+    assertEquals(stubProfile.getPolicies().length(), 3);
+    assertEquals(stubProfile.getPolicies().getJSONObject(0).getString("roleId"), "bar");
+    assertEquals(stubProfile.getPolicies().getJSONObject(1).getString("roleId"), "baz");
+    assertEquals(stubProfile.getPolicies().getJSONObject(2).getString("roleId"), "qux");
   }
 
   @Test
   public void testSetRolesIDs() throws JSONException {
-    String[] roles = {"bar", "baz", "qux" };
+    String[] policies = {"bar", "baz", "qux"};
 
-    stubProfile.addRole("foo");
-    stubProfile.setRoles(roles);
-    assertEquals(stubProfile.getRoles().length, 3);
-    assertEquals(stubProfile.getRoles()[0].id, "bar");
-    assertEquals(stubProfile.getRoles()[1].id, "baz");
-    assertEquals(stubProfile.getRoles()[2].id, "qux");
+    stubProfile.addPolicy("foo");
+    stubProfile.setPolicies(policies);
+    assertEquals(stubProfile.getPolicies().length(), 4);
+    assertEquals(stubProfile.getPolicies().getJSONObject(0).getString("roleId"), "foo");
+    assertEquals(stubProfile.getPolicies().getJSONObject(1).getString("roleId"), "bar");
+    assertEquals(stubProfile.getPolicies().getJSONObject(2).getString("roleId"), "baz");
+    assertEquals(stubProfile.getPolicies().getJSONObject(3).getString("roleId"), "qux");
   }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testHydrateNoListener() throws JSONException {
-    stubProfile.hydrate(null, null);
-  }
-
-  @Test
-  public void testHydrateValid() throws JSONException {
-    doAnswer(new Answer() {
-      @Override
-      public Object answer(InvocationOnMock invocation) throws Throwable {
-        JSONObject response = new JSONObject(
-          "{" +
-            "\"result\": {" +
-              "\"hits\": [" +
-                "{" +
-                  "\"_id\": \"qux\"," +
-                  "\"_source\": {" +
-                    "\"_id\": \"qux\"," +
-                    "\"some\": \"content\"" +
-                  "}" +
-                "}" +
-              "]," +
-              "\"total\": 1" +
-            "}" +
-          "}");
-
-        ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(response);
-        ((OnQueryDoneListener) invocation.getArguments()[3]).onError(new JSONObject().put("error", "stub"));
-        return null;
-      }
-    }).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
-
-    stubProfile.addRole("qux");
-
-    stubProfile.hydrate(new KuzzleResponseListener<KuzzleProfile>() {
-      @Override
-      public void onSuccess(KuzzleProfile response) {
-        assertEquals(response.getRoles().length, 1);
-        assertEquals(response.getRoles()[0].id, "qux");
-
-        try {
-          assertEquals(response.getRoles()[0].content.getString("some"), "content");
-        }
-        catch(JSONException e) {
-          throw new RuntimeException(e);
-        }
-      }
-
-      @Override
-      public void onError(JSONObject error) {
-        try {
-          assertEquals(error.getString("error"), "stub");
-        } catch (JSONException e) {
-          throw new RuntimeException(e);
-        }
-      }
-    });
-
-    ArgumentCaptor argument = ArgumentCaptor.forClass(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class);
-    verify(kuzzle, times(1)).query((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.capture(), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
-    assertEquals(((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.getValue()).controller, "security");
-    assertEquals(((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.getValue()).action, "mGetRoles");
-  }
-
-  @Test(expected = RuntimeException.class)
-  public void testHydrateBadResponse() throws JSONException {
-    doAnswer(new Answer() {
-      @Override
-      public Object answer(InvocationOnMock invocation) throws Throwable {
-        JSONObject response = new JSONObject();
-
-        ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(response);
-        return null;
-      }
-    }).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
-
-    stubProfile.addRole("qux");
-    stubProfile.hydrate(listener);
-  }
-
 }

--- a/src/test/java/io/kuzzle/test/security/KuzzleProfileTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleProfileTest.java
@@ -180,4 +180,11 @@ public class KuzzleProfileTest {
     assertEquals(stubProfile.getPolicies().getJSONObject(2).getString("roleId"), "baz");
     assertEquals(stubProfile.getPolicies().getJSONObject(3).getString("roleId"), "qux");
   }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testSetBadPolicies() throws JSONException {
+    stubProfile.setPolicies(new JSONArray("[{\"bad\":\"policy\"}]"));
+
+    doThrow(IllegalArgumentException.class).when(stubProfile).setPolicies(any(JSONArray.class));
+  }
 }

--- a/src/test/java/io/kuzzle/test/security/KuzzleProfileTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleProfileTest.java
@@ -14,15 +14,14 @@ import io.kuzzle.sdk.core.KuzzleOptions;
 import io.kuzzle.sdk.listeners.KuzzleResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.security.KuzzleProfile;
-import io.kuzzle.sdk.security.KuzzleRole;
 import io.kuzzle.sdk.security.KuzzleSecurity;
 
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -186,5 +185,10 @@ public class KuzzleProfileTest {
     stubProfile.setPolicies(new JSONArray("[{\"bad\":\"policy\"}]"));
 
     doThrow(IllegalArgumentException.class).when(stubProfile).setPolicies(any(JSONArray.class));
+  }
+
+  @Test
+  public void testSerializeWithNoPolicies() throws JSONException {
+    assertFalse(stubProfile.serialize().getJSONObject("body").has("policies"));
   }
 }

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/AbstractKuzzleSecurityDocumentTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/AbstractKuzzleSecurityDocumentTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -36,7 +37,7 @@ public class AbstractKuzzleSecurityDocumentTest {
     kuzzle = mock(Kuzzle.class);
     kuzzle.security = new KuzzleSecurity(kuzzle);
     listener = mock(KuzzleResponseListener.class);
-    stubRole = new KuzzleRole(kuzzle, "foo", null);
+    stubRole = new KuzzleRole(kuzzle, "foo", new JSONObject("{\"foo\":\"bar\"}"));
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -178,4 +179,8 @@ public class AbstractKuzzleSecurityDocumentTest {
     stubRole.update(new JSONObject(), listener);
   }
 
+  @Test
+  public void testGetContent() throws JSONException {
+    assertTrue(stubRole.getContent().getString("foo").equals("bar"));
+  }
 }

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/getProfileTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/getProfileTest.java
@@ -4,7 +4,6 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -12,15 +11,11 @@ import io.kuzzle.sdk.core.Kuzzle;
 import io.kuzzle.sdk.core.KuzzleOptions;
 import io.kuzzle.sdk.listeners.KuzzleResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
-import io.kuzzle.sdk.security.KuzzleProfile;
 import io.kuzzle.sdk.security.KuzzleSecurity;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 public class getProfileTest {
   private Kuzzle kuzzle;
@@ -41,108 +36,6 @@ public class getProfileTest {
   @Test(expected = IllegalArgumentException.class)
   public void testGetProfileNoListener() throws JSONException {
     kuzzleSecurity.getProfile("foo", null);
-  }
-
-  @Test
-  public void testgetProfileValidResponseWithoutHydrate() throws JSONException {
-    doAnswer(new Answer() {
-      @Override
-      public Object answer(InvocationOnMock invocation) throws Throwable {
-        JSONObject response = new JSONObject(
-          "{" +
-            "\"result\": {" +
-            "\"_id\": \"foobar\"," +
-            "\"_source\": {" +
-              "\"roles\": [{\"_id\": \"foo\", \"_source\": {\"restrictedTo\": []," +
-              "\"allowInternalIndex\": true}" +
-              "}" +
-              "]" +
-            "}" +
-            "}" +
-              "}");
-
-        ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(response);
-        ((OnQueryDoneListener) invocation.getArguments()[3]).onError(new JSONObject().put("error", "stub"));
-        return null;
-      }
-    }).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
-
-    KuzzleOptions options = new KuzzleOptions();
-    options.setHydrate(false);
-
-    kuzzleSecurity.getProfile("foobar", options, new KuzzleResponseListener<KuzzleProfile>() {
-      @Override
-      public void onSuccess(KuzzleProfile response) {
-        assertEquals(response.id, "foobar");
-        assertEquals(true, response.getRoles()[0].getContent().has("restrictedTo"));
-        try {
-          assertEquals(true, response.getRoles()[0].getContent().getBoolean("allowInternalIndex"));
-        } catch (JSONException e) {
-          e.printStackTrace();
-        }
-      }
-
-      @Override
-      public void onError(JSONObject error) {
-        try {
-          assertEquals(error.getString("error"), "stub");
-        } catch (JSONException e) {
-          throw new RuntimeException(e);
-        }
-      }
-    });
-
-    ArgumentCaptor argument = ArgumentCaptor.forClass(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class);
-    verify(kuzzle, times(1)).query((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.capture(), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
-    assertEquals(((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.getValue()).controller, "security");
-    assertEquals(((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.getValue()).action, "getProfile");
-  }
-
-  @Test
-  public void testgetProfileValidResponseWithHydrate() throws JSONException {
-    doAnswer(new Answer() {
-      @Override
-      public Object answer(InvocationOnMock invocation) throws Throwable {
-        JSONObject response = new JSONObject(
-            "{" +
-                "\"result\": {" +
-                "\"_id\": \"foobar\"," +
-                "\"_source\": {" +
-                "\"roles\": [{\"_id\": \"foo\", \"_source\": {\"foo\": []," +
-                "}" +
-                "}" +
-                "]" +
-                "}" +
-                "}" +
-                "}");
-
-        ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(response);
-        ((OnQueryDoneListener) invocation.getArguments()[3]).onError(new JSONObject().put("error", "stub"));
-        return null;
-      }
-    }).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
-
-    kuzzleSecurity.getProfile("foobar", new KuzzleResponseListener<KuzzleProfile>() {
-      @Override
-      public void onSuccess(KuzzleProfile response) {
-        assertEquals(response.id, "foobar");
-        assertEquals(true, response.getRoles()[0].getContent().has("foo"));
-      }
-
-      @Override
-      public void onError(JSONObject error) {
-        try {
-          assertEquals(error.getString("error"), "stub");
-        } catch (JSONException e) {
-          throw new RuntimeException(e);
-        }
-      }
-    });
-
-    ArgumentCaptor argument = ArgumentCaptor.forClass(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class);
-    verify(kuzzle, times(1)).query((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.capture(), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
-    assertEquals(((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.getValue()).controller, "security");
-    assertEquals(((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.getValue()).action, "getProfile");
   }
 
   @Test(expected = RuntimeException.class)

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/getProfileTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/getProfileTest.java
@@ -46,6 +46,7 @@ public class getProfileTest {
         JSONObject response = new JSONObject();
 
         ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(response);
+        ((OnQueryDoneListener) invocation.getArguments()[3]).onError(new JSONObject().put("error", "stub"));
         return null;
       }
     }).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
@@ -54,13 +55,66 @@ public class getProfileTest {
   }
 
   @Test
-  public void testgetProfileGoodResponse() throws JSONException {
+  public void testgetProfileGoodFullResponse() throws JSONException {
     doAnswer(new Answer() {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {
         JSONObject response = new JSONObject("{\"result\":{\"_id\":\"foobar\",\"_source\":{\"policies\":[{\"roleId\":\"baz\",\"restrictedTo\":[{\"index\":\"qux\"}],\"allowInternalIndex\":true}]}}}");
 
         ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(response);
+        ((OnQueryDoneListener) invocation.getArguments()[3]).onError(new JSONObject().put("error", "stub"));
+
+        return null;
+      }
+    }).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
+
+    kuzzleSecurity.getProfile("foobar", listener);
+  }
+
+  @Test
+  public void testgetProfileGoodMinimalResponse() throws JSONException {
+    doAnswer(new Answer() {
+      @Override
+      public Object answer(InvocationOnMock invocation) throws Throwable {
+        JSONObject response = new JSONObject("{\"result\":{\"_id\":\"foobar\",\"_source\":{\"policies\":[{\"roleId\":\"baz\"}]}}}");
+
+        ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(response);
+        ((OnQueryDoneListener) invocation.getArguments()[3]).onError(new JSONObject().put("error", "stub"));
+
+        return null;
+      }
+    }).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
+
+    kuzzleSecurity.getProfile("foobar", listener);
+  }
+
+  @Test
+  public void testgetProfileGoodWithRestrictedToResponse() throws JSONException {
+    doAnswer(new Answer() {
+      @Override
+      public Object answer(InvocationOnMock invocation) throws Throwable {
+        JSONObject response = new JSONObject("{\"result\":{\"_id\":\"foobar\",\"_source\":{\"policies\":[{\"roleId\":\"baz\"}],\"restrictedTo\":[{\"index\":\"qux\"}]}}}");
+
+        ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(response);
+        ((OnQueryDoneListener) invocation.getArguments()[3]).onError(new JSONObject().put("error", "stub"));
+
+        return null;
+      }
+    }).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
+
+    kuzzleSecurity.getProfile("foobar", listener);
+  }
+
+  @Test
+  public void testgetProfileGoodWithAllowInternalIndexResponse() throws JSONException {
+    doAnswer(new Answer() {
+      @Override
+      public Object answer(InvocationOnMock invocation) throws Throwable {
+        JSONObject response = new JSONObject("{\"result\":{\"_id\":\"foobar\",\"_source\":{\"policies\":[{\"roleId\":\"baz\"}],\"allowInternalIndex\":true}}}");
+
+        ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(response);
+        ((OnQueryDoneListener) invocation.getArguments()[3]).onError(new JSONObject().put("error", "stub"));
+
         return null;
       }
     }).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/getProfileTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/getProfileTest.java
@@ -53,4 +53,19 @@ public class getProfileTest {
     kuzzleSecurity.getProfile("foobar", listener);
   }
 
+  @Test
+  public void testgetProfileGoodResponse() throws JSONException {
+    doAnswer(new Answer() {
+      @Override
+      public Object answer(InvocationOnMock invocation) throws Throwable {
+        JSONObject response = new JSONObject("{\"result\":{\"_id\":\"foobar\",\"_source\":{\"policies\":[{\"roleId\":\"baz\",\"restrictedTo\":[{\"index\":\"qux\"}],\"allowInternalIndex\":true}]}}}");
+
+        ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(response);
+        return null;
+      }
+    }).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
+
+    kuzzleSecurity.getProfile("foobar", listener);
+  }
+
 }

--- a/src/test/java/io/kuzzle/test/security/KuzzleUserTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleUserTest.java
@@ -1,5 +1,6 @@
 package io.kuzzle.test.security;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -12,7 +13,6 @@ import io.kuzzle.sdk.core.Kuzzle;
 import io.kuzzle.sdk.core.KuzzleOptions;
 import io.kuzzle.sdk.listeners.KuzzleResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
-import io.kuzzle.sdk.security.KuzzleProfile;
 import io.kuzzle.sdk.security.KuzzleSecurity;
 import io.kuzzle.sdk.security.KuzzleUser;
 
@@ -20,7 +20,9 @@ import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -53,7 +55,7 @@ public class KuzzleUserTest {
   public void testKuzzleUserConstructorNoContent() throws JSONException {
     KuzzleUser user = new KuzzleUser(kuzzle, "foo", null);
     assertEquals(user.id, "foo");
-    assertEquals(user.profile, null);
+    assertEquals(user.getProfiles(), null);
     assertThat(user.content, instanceOf(JSONObject.class));
   }
 
@@ -61,126 +63,40 @@ public class KuzzleUserTest {
   public void testKuzzleUserConstructorWithEmptyProfile() throws JSONException {
     JSONObject stubProfile = new JSONObject(
       "{" +
-        "\"profile\": {" +
-          "\"_id\": \"bar\"," +
-        "}," +
+        "\"profilesIds\": [\"bar\"]," +
         "\"someuseless\": \"field\"" +
       "}"
     );
     KuzzleUser user = new KuzzleUser(kuzzle, "foo", stubProfile);
     assertEquals(user.id, "foo");
-    assertThat(user.profile, instanceOf(KuzzleProfile.class));
-    assertEquals(user.profile.id, "bar");
-    assertEquals(user.profile.content.length(), 0);
+    assertEquals(user.getProfiles().getString(0), "bar");
     assertThat(user.content, instanceOf(JSONObject.class));
     assertEquals(user.content.getString("someuseless"), "field");
   }
 
   @Test
   public void testKuzzleUserConstructorProfileWithContent() throws JSONException {
-    JSONObject stubProfile = new JSONObject(
-      "{" +
-        "\"profile\": {" +
-          "\"_id\": \"bar\"," +
-          "\"_source\": {" +
-            "\"bohemian\": \"rhapsody\"" +
-          "}" +
-        "}" +
-      "}"
-    );
+    JSONObject stubProfile = new JSONObject("{\"profilesIds\": [\"bar\"]}");
     KuzzleUser user = new KuzzleUser(kuzzle, "foo", stubProfile);
     assertEquals(user.id, "foo");
-    assertThat(user.profile, instanceOf(KuzzleProfile.class));
-    assertEquals(user.profile.id, "bar");
-    assertThat(user.profile.content, instanceOf(JSONObject.class));
-    assertEquals(user.profile.content.getString("bohemian"), "rhapsody");
+    assertThat(user.getProfiles(), instanceOf(JSONArray.class));
+    assertEquals(user.getProfiles().getString(0), "bar");
     assertThat(user.content, instanceOf(JSONObject.class));
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testHydrateNoListener() throws JSONException {
-    stubUser.hydrate(null, null);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testHydrateNoProfile() throws JSONException {
-    stubUser.hydrate(null, listener);
-  }
-
-  @Test
-  public void testHydrateValidResponse() throws JSONException {
-    doAnswer(new Answer() {
-      @Override
-      public Object answer(InvocationOnMock invocation) throws Throwable {
-        JSONObject response = new JSONObject().put("result", stubProfile.getJSONObject("profile"));
-        ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(response);
-        ((OnQueryDoneListener) invocation.getArguments()[3]).onError(new JSONObject().put("error", "stub"));
-        return null;
-      }
-    }).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
-
-    stubUser.profile = new KuzzleProfile(kuzzle, "bar", null);
-    stubUser.hydrate(new KuzzleResponseListener<KuzzleUser>() {
-      @Override
-      public void onSuccess(KuzzleUser response) {
-        assertEquals(response.id, "foo");
-        assertThat(response.profile, instanceOf(KuzzleProfile.class));
-        assertEquals(response.profile.id, "bar");
-      }
-
-      @Override
-      public void onError(JSONObject error) {
-        try {
-          assertEquals(error.getString("error"), "stub");
-        } catch (JSONException e) {
-          throw new RuntimeException(e);
-        }
-      }
-    });
-
-    ArgumentCaptor argument = ArgumentCaptor.forClass(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class);
-    verify(kuzzle, times(1)).query((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.capture(), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
-    assertEquals(((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.getValue()).controller, "security");
-    assertEquals(((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.getValue()).action, "getProfile");
-  }
-
-  @Test(expected = RuntimeException.class)
-  public void testHydrateBadResponse() throws JSONException {
-    doAnswer(new Answer() {
-      @Override
-      public Object answer(InvocationOnMock invocation) throws Throwable {
-        ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(new JSONObject());
-        ((OnQueryDoneListener) invocation.getArguments()[3]).onError(new JSONObject().put("error", "stub"));
-        return null;
-      }
-    }).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
-
-    stubUser.profile = new KuzzleProfile(kuzzle, "bar", null);
-    stubUser.hydrate(listener);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testSetProfileNullProfile() {
-    stubUser.setProfile((KuzzleProfile) null);
   }
 
   @Test
   public void testSetProfileWithKuzzleProfile() throws JSONException {
-    stubUser.setProfile(new KuzzleProfile(kuzzle, "some profile", null));
-    assertThat(stubUser.profile, instanceOf(KuzzleProfile.class));
-    assertEquals(stubUser.profile.id, "some profile");
+    String[] ids = new String[1];
+    ids[0] = "foo";
+    stubUser.setProfiles(ids);
+    assertEquals(stubUser.getProfiles().getString(0), "foo");
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testSetProfileNullID() throws JSONException {
-    stubUser.setProfile((String) null);
-  }
-
-  @Test
-  public void testSetProfileWithStringID() throws JSONException {
-    stubUser.setProfile("some profile");
-    assertThat(stubUser.profile, instanceOf(KuzzleProfile.class));
-    assertEquals(stubUser.profile.id, "some profile");
+    String[] ids = null;
+    stubUser.setProfiles(ids);
+    doThrow(IllegalArgumentException.class).when(stubUser).setProfiles(any(String[].class));
   }
 
   @Test
@@ -239,26 +155,39 @@ public class KuzzleUserTest {
   @Test
   public void testSerializeWithProfile() throws JSONException {
     stubUser.content.put("foo", "bar");
-    stubUser.profile = new KuzzleProfile(kuzzle, "bar", null);
+    stubUser.setProfiles(new String[]{"profile"});
     JSONObject serialized = stubUser.serialize();
     assertEquals(serialized.getString("_id"), stubUser.id);
     assertEquals(serialized.getJSONObject("body").getString("foo"), "bar");
-    assertEquals(serialized.getJSONObject("body").getString("profile"), stubUser.profile.id);
+    assertEquals(serialized.getJSONObject("body").getJSONArray("profilesIds").getString(0), stubUser.getProfiles().getString(0));
   }
 
   @Test
   public void testGetProfiles() throws JSONException {
     JSONObject stubProfile = new JSONObject(
-        "{" +
-            "\"profile\": {" +
-            "\"_id\": \"bar\"," +
-            "\"_source\": {" +
-            "\"bohemian\": \"rhapsody\"" +
-            "}" +
-            "}" +
-            "}"
+            "{\"profilesIds\": [\"bar\"]}"
     );
     KuzzleUser user = new KuzzleUser(kuzzle, "foo", stubProfile);
-    assertEquals(user.getProfiles()[0].getId(), "bar");
+    assertEquals(user.getProfiles().getString(0), "bar");
+  }
+
+  @Test
+  public void testAddProfile() throws JSONException {
+    JSONObject stubProfile = new JSONObject(
+            "{\"profilesIds\": [\"bar\"]}"
+    );
+    KuzzleUser user = new KuzzleUser(kuzzle, "foo", stubProfile);
+    user.addProfile("new profile");
+    assertEquals(user.getProfiles().getString(1), "new profile");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testAddNullProfile() throws JSONException {
+    JSONObject stubProfile = new JSONObject(
+            "{\"profilesIds\": [\"bar\"]}"
+    );
+    KuzzleUser user = new KuzzleUser(kuzzle, "foo", stubProfile);
+    user.addProfile(null);
+    doThrow(IllegalArgumentException.class).when(user).addProfile(eq((String)null));
   }
 }


### PR DESCRIPTION
Changed the Kuzzle constructor according to the latest SDK specifications, taking a `host` name/address instead of an `url`, with an additional `port` option defaulted to 7512.
