### PR TITLE
updated kuzzle constructor to latest version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jdk:
 android:
     components:
         - tools
-        - build-tools-23.0.1
+        - build-tools-23.0.2
         - platform-tools
         - android-23
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Official Kuzzle Android SDK
 ======
 
-This SDK version requires Kuzzle v1.0.0-beta.6 or higher.
+This SDK version requires Kuzzle v1.0.0-RC5 or higher.
 
 ## About Kuzzle
 
@@ -16,7 +16,7 @@ You can access the Kuzzle repository on [Github](https://github.com/kuzzleio/kuz
 
 ## SDK Documentation
 
-The complete SDK documentation is available [here](http://kuzzleio.github.io/sdk-documentation)
+The complete SDK documentation is available [here](http://kuzzle.io/sdk-documentation)
 
 ## Installation
 
@@ -27,12 +27,12 @@ You can configure your android project to get the Kuzzle's android SDK from jcen
             jcenter()
         }
     }
-    compile 'io.kuzzle:sdk-android:1.6.0'
+    compile 'io.kuzzle:sdk-android:2.0.0'
 
 ## Basic usage
 
 ```java
-Kuzzle kuzzle = new Kuzzle("http://host.url", "index", new ResponseListener<Void>() {
+Kuzzle kuzzle = new Kuzzle("host", new ResponseListener<Void>() {
 @Override
 public void onSuccess(Void object) {
     // Handle success
@@ -64,7 +64,7 @@ myDocument.publish();
 
 ## Adding metadata
 
-As stated [here](http://kuzzleio.github.io/kuzzle-api-documentation/#sending-metadata) you can add metadata to a subscription.
+As stated [here](http://kuzzle.io/api-reference/#sending-metadata) you can add metadata to a subscription.
 
 ```java
 KuzzleOptions options = new KuzzleOptions();
@@ -87,7 +87,7 @@ If you have the kuzzle-plugin-auth-passport-local installed you can login using 
 
 ```java
 KuzzleOptions options = new KuzzleOptions();
-kuzzle = new Kuzzle("http://localhost:7512", "index", options);
+kuzzle = new Kuzzle("localhost", options);
 ```
 
 ## Login with an OAuth strategy

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'jacoco-android'
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 
-version = "1.7.0"
+version = "2.0.0"
 
 buildscript {
     repositories {
@@ -14,13 +14,13 @@ buildscript {
         classpath 'com.android.tools.build:gradle:2.1.2'
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
     }
 }
 
 android {
     compileSdkVersion 23
-    buildToolsVersion '23.0.1'
+    buildToolsVersion '23.0.2'
     defaultConfig {
         minSdkVersion 10
         targetSdkVersion 10

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,4 @@
 # org.gradle.parallel=true
 #Mon Feb 08 14:31:09 CET 2016
 systemProp.http.proxyHost=
-systemProp.http.proxyPort=3128
+systemProp.http.proxyPort=

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Oct 22 17:22:25 CEST 2015
+#Thu Aug 04 16:08:53 CEST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
+++ b/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
@@ -1753,6 +1753,16 @@ public class Kuzzle {
     return autoReplay;
   }
 
+
+  /**
+   * Gets network port
+   *
+   * @return integer
+   */
+  public int getPort() {
+    return port;
+  }
+
   /**
    * Sets auto replay.
    *

--- a/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
+++ b/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
@@ -76,9 +76,13 @@ public class Kuzzle {
    */
   protected JSONObject metadata;
   /**
-   * The Url.
+   * The target Kuzzle URL
    */
   protected String url;
+  /**
+   * Target Kuzzle network port
+   */
+  protected Integer port;
   /**
    * The Connection callback.
    */
@@ -170,9 +174,8 @@ public class Kuzzle {
   private KuzzleOfflineQueueLoader  offlineQueueLoader;
 
   /**
-   * The constant security.
+   * Security static class
    */
-// Security static class
   public KuzzleSecurity security;
 
   private KuzzleResponseListener<JSONObject>  loginCallback;
@@ -227,14 +230,14 @@ public class Kuzzle {
   /**
    * Kuzzle object constructor.
    *
-   * @param url                the url
+   * @param host               target host name or IP address
    * @param options            the options
    * @param connectionCallback the connection callback
    * @throws URISyntaxException the uri syntax exception
    */
-  public Kuzzle(@NonNull final String url, final KuzzleOptions options, final KuzzleResponseListener<Void> connectionCallback) throws URISyntaxException {
-    if (url == null || url.isEmpty()) {
-      throw new IllegalArgumentException("Url can't be empty");
+  public Kuzzle(@NonNull final String host, final KuzzleOptions options, final KuzzleResponseListener<Void> connectionCallback) throws URISyntaxException {
+    if (host == null || host.isEmpty()) {
+      throw new IllegalArgumentException("Host name/address can't be empty");
     }
 
     KuzzleOptions opt = (options != null ? options : new KuzzleOptions());
@@ -246,12 +249,13 @@ public class Kuzzle {
     this.defaultIndex = opt.getDefaultIndex();
     this.headers = opt.getHeaders();
     this.metadata = opt.getMetadata();
+    this.port = opt.getPort();
     this.queueMaxSize = opt.getQueueMaxSize();
     this.queueTTL = opt.getQueueTTL();
     this.reconnectionDelay = opt.getReconnectionDelay();
     this.replayInterval = opt.getReplayInterval();
 
-    this.url = url;
+    this.url = "http://" + host + ":" + this.port;
     this.connectionCallback = connectionCallback;
 
     if (socket == null) {
@@ -275,33 +279,33 @@ public class Kuzzle {
   /**
    * Instantiates a new Kuzzle.
    *
-   * @param url the url
+   * @param host target Kuzzle host name or IP address
    * @throws URISyntaxException the uri syntax exception
    */
-  public Kuzzle(@NonNull final String url) throws URISyntaxException {
-    this(url, null, null);
+  public Kuzzle(@NonNull final String host) throws URISyntaxException {
+    this(host, null, null);
   }
 
   /**
    * Instantiates a new Kuzzle.
    *
-   * @param url the url
+   * @param host target Kuzzle host name or IP address
    * @param cb  the cb
    * @throws URISyntaxException the uri syntax exception
    */
-  public Kuzzle(@NonNull final String url, final KuzzleResponseListener<Void> cb) throws URISyntaxException {
-    this(url, null, cb);
+  public Kuzzle(@NonNull final String host, final KuzzleResponseListener<Void> cb) throws URISyntaxException {
+    this(host, null, cb);
   }
 
   /**
    * Instantiates a new Kuzzle.
    *
-   * @param url     the url
+   * @param host target Kuzzle host name or IP address
    * @param options the options
    * @throws URISyntaxException the uri syntax exception
    */
-  public Kuzzle(@NonNull final String url, KuzzleOptions options) throws URISyntaxException {
-    this(url, options, null);
+  public Kuzzle(@NonNull final String host, KuzzleOptions options) throws URISyntaxException {
+    this(host, options, null);
   }
 
   /**

--- a/src/main/java/io/kuzzle/sdk/core/KuzzleOptions.java
+++ b/src/main/java/io/kuzzle/sdk/core/KuzzleOptions.java
@@ -28,6 +28,7 @@ public class KuzzleOptions {
   private boolean replaceIfExist = false;
   private Long from;
   private Long size;
+  private Integer port = 7512;
 
   // Used for getting collections
   private KuzzleCollectionType  collectionType = KuzzleCollectionType.ALL;
@@ -386,5 +387,13 @@ public class KuzzleOptions {
 
   public void setSize(Long size) {
     this.size = size;
+  }
+
+  public void setPort(Integer port) {
+    this.port = port;
+  }
+
+  public Integer getPort() {
+    return this.port;
   }
 }

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/checkTokenTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/checkTokenTest.java
@@ -38,7 +38,7 @@ public class checkTokenTest {
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");
 
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(mock(Socket.class));
 
     listener = new KuzzleResponseListener<Object>() {

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/connectionManagementTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/connectionManagementTest.java
@@ -66,7 +66,7 @@ public class connectionManagementTest {
 
       }
     };
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, listener);
+    kuzzle = new KuzzleExtend("localhost", options, listener);
     kuzzle.setSocket(s);
   }
 
@@ -86,7 +86,7 @@ public class connectionManagementTest {
     JSONObject query = new JSONObject("{\"controller\":\"test3\",\"metadata\":{},\"requestId\":\"a476ae61-497e-4338-b4dd-751ac22c6b61\",\"action\":\"test3\",\"collection\":\"test3\"}");
     o.setQuery(query);
 
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(s);
 
     doAnswer(new Answer() {
@@ -122,7 +122,7 @@ public class connectionManagementTest {
     options.setConnect(Mode.MANUAL);
     options.setAutoReconnect(true);
     options.setOfflineMode(Mode.AUTO);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", options, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", options, null);
     extended.setSocket(s);
     extended.setState(KuzzleStates.INITIALIZING);
     final Kuzzle kuzzleSpy = spy(extended);
@@ -175,7 +175,7 @@ public class connectionManagementTest {
       }
     }).when(s).once(eq(Socket.EVENT_DISCONNECT), any(Emitter.Listener.class));
 
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(s);
     kuzzle = spy(kuzzle);
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/constructorTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/constructorTest.java
@@ -37,6 +37,7 @@ public class constructorTest {
   public void setUp() throws URISyntaxException {
     KuzzleOptions options = new KuzzleOptions();
     options.setConnect(Mode.MANUAL);
+    options.setPort(12345);
     options.setDefaultIndex("testIndex");
 
     s = mock(Socket.class);
@@ -262,5 +263,10 @@ public class constructorTest {
   @Test
   public void exposeReconnectionDelayGetter() {
     assertThat(kuzzle.getReconnectionDelay(), instanceOf(long.class));
+  }
+
+  @Test
+  public void testGetPort() {
+    assertEquals(kuzzle.getPort(), 12345);
   }
 }

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/constructorTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/constructorTest.java
@@ -40,7 +40,7 @@ public class constructorTest {
     options.setDefaultIndex("testIndex");
 
     s = mock(Socket.class);
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(s);
 
     listener = new KuzzleResponseListener<Object>() {
@@ -63,11 +63,11 @@ public class constructorTest {
 
   @Test
   public void checkSignaturesVariants() throws URISyntaxException {
-    Kuzzle k = new Kuzzle("http://localhost:7512");
+    Kuzzle k = new Kuzzle("localhost");
     assertNotNull(k);
-    k = new Kuzzle("http://localhost:7512", new KuzzleOptions());
+    k = new Kuzzle("localhost", new KuzzleOptions());
     assertNotNull(k);
-    k = new Kuzzle("http://localhost:7512", listener);
+    k = new Kuzzle("localhost", listener);
     assertNotNull(k);
   }
 
@@ -120,7 +120,7 @@ public class constructorTest {
     KuzzleOptions options = new KuzzleOptions();
     options.setQueuable(false);
     options.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", options, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", options, null);
     extended.setSocket(s);
     extended.setState(KuzzleStates.CONNECTED);
 
@@ -147,7 +147,7 @@ public class constructorTest {
     options.setMetadata(meta);
     options.setQueuable(false);
     options.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", options, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", options, null);
     extended.setSocket(s);
     extended.setState(KuzzleStates.CONNECTED);
     extended.query(QueryArgsHelper.makeQueryArgs("controller", "action"), jsonObj, options);

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/eventSystemTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/eventSystemTest.java
@@ -43,7 +43,7 @@ public class eventSystemTest {
     options.setDefaultIndex("testIndex");
 
     s = mock(Socket.class);
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(s);
 
     listener = new KuzzleResponseListener<Object>() {

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/factoriesTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/factoriesTest.java
@@ -27,7 +27,7 @@ public class factoriesTest {
     options.setDefaultIndex("testIndex");
 
     s = mock(Socket.class);
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(s);
 
     listener = new KuzzleResponseListener<Object>() {

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/getAllStatisticsTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/getAllStatisticsTest.java
@@ -41,7 +41,7 @@ public class getAllStatisticsTest {
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");
 
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(mock(Socket.class));
 
     listener = new KuzzleResponseListener<Object>() {

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/getAutoRefreshTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/getAutoRefreshTest.java
@@ -40,7 +40,7 @@ public class getAutoRefreshTest {
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");
 
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(mock(Socket.class));
 
     listener = mock(KuzzleResponseListener.class);

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/getLastStatisticsTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/getLastStatisticsTest.java
@@ -37,7 +37,7 @@ public class getLastStatisticsTest {
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");
 
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(mock(Socket.class));
 
     listener = new KuzzleResponseListener<Object>() {

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/getMyRightsTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/getMyRightsTest.java
@@ -32,7 +32,7 @@ public class getMyRightsTest {
 
   @Before
   public void setUp() throws URISyntaxException {
-    kuzzle = spy(new KuzzleExtend("http://localhost:7512", mock(KuzzleOptions.class), mock(KuzzleResponseListener.class)));
+    kuzzle = spy(new KuzzleExtend("localhost", mock(KuzzleOptions.class), mock(KuzzleResponseListener.class)));
     listener = mock(KuzzleResponseListener.class);
   }
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/getServerInfoTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/getServerInfoTest.java
@@ -37,7 +37,7 @@ public class getServerInfoTest {
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");
 
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(mock(Socket.class));
 
     listener = new KuzzleResponseListener<Object>() {

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/getStatisticsTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/getStatisticsTest.java
@@ -40,7 +40,7 @@ public class getStatisticsTest {
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");
 
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(mock(Socket.class));
 
     listener = new KuzzleResponseListener<Object>() {

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/kuzzleWebViewTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/kuzzleWebViewTest.java
@@ -32,7 +32,7 @@ public class kuzzleWebViewTest {
     options.setDefaultIndex("testIndex");
 
     s = mock(Socket.class);
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(s);
     webViewClient = kuzzle.getKuzzleWebViewClient();
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/listCollectionsTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/listCollectionsTest.java
@@ -37,7 +37,7 @@ public class listCollectionsTest {
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");
 
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(mock(Socket.class));
 
     listener = new KuzzleResponseListener<Object>() {

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/listIndexesTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/listIndexesTest.java
@@ -38,7 +38,7 @@ public class listIndexesTest {
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");
 
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(mock(Socket.class));
 
     listener = new KuzzleResponseListener<Object>() {

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/loginTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/loginTest.java
@@ -41,7 +41,7 @@ public class loginTest {
     options.setDefaultIndex("testIndex");
 
     s = mock(Socket.class);
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(s);
 
     listener = new KuzzleResponseListener<Object>() {

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/logoutTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/logoutTest.java
@@ -40,7 +40,7 @@ public class logoutTest {
     options.setDefaultIndex("testIndex");
 
     s = mock(Socket.class);
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(s);
 
     listener = new KuzzleResponseListener<Object>() {

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/nowTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/nowTest.java
@@ -39,7 +39,7 @@ public class nowTest {
     options.setDefaultIndex("testIndex");
 
     s = mock(Socket.class);
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(s);
 
     listener = new KuzzleResponseListener<Object>() {

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/offlineQueueLoaderTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/offlineQueueLoaderTest.java
@@ -41,7 +41,7 @@ public class offlineQueueLoaderTest {
     KuzzleOptions options = new KuzzleOptions();
     options.setConnect(Mode.MANUAL);
     s = mock(Socket.class);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", options, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", options, null);
     extended.setSocket(s);
     kuzzleExtend = extended;
   }

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/queryTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/queryTest.java
@@ -45,7 +45,7 @@ public class queryTest {
     KuzzleOptions options = new KuzzleOptions();
     options.setConnect(Mode.MANUAL);
 
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setState(KuzzleStates.CONNECTED);
     kuzzle.setSocket(socket);
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/queueManagementTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/queueManagementTest.java
@@ -42,7 +42,7 @@ public class queueManagementTest {
     options.setDefaultIndex("testIndex");
 
     s = mock(Socket.class);
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(s);
 
     listener = new KuzzleResponseListener<Object>() {
@@ -67,7 +67,7 @@ public class queueManagementTest {
     options.setAutoReconnect(true);
     options.setOfflineMode(Mode.AUTO);
 
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     KuzzleQueryObject o = new KuzzleQueryObject();
     o.setTimestamp(new Date());
     o.setAction("test");
@@ -89,7 +89,7 @@ public class queueManagementTest {
     options.setQueueTTL(10000);
     options.setReplayInterval(1);
     options.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", options, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", options, null);
     extended.setSocket(s);
     extended.setState(KuzzleStates.CONNECTED);
 
@@ -125,7 +125,7 @@ public class queueManagementTest {
     KuzzleOptions options = new KuzzleOptions();
     options.setAutoReconnect(false);
     options.setDefaultIndex("testIndex");
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.connect();
     kuzzle.listCollections(mock(KuzzleResponseListener.class));
     assertEquals(kuzzle.getOfflineQueue().size(), 1);
@@ -145,7 +145,7 @@ public class queueManagementTest {
     options.setAutoReplay(true);
     options.setConnect(Mode.MANUAL);
     options.setOfflineMode(Mode.AUTO);
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(s);
 
     doAnswer(new Answer() {
@@ -174,7 +174,7 @@ public class queueManagementTest {
     options.setReplayInterval(1);
     options.setConnect(Mode.MANUAL);
     options.setOfflineMode(Mode.AUTO);
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(s);
 
     doAnswer(new Answer() {

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/refreshIndexTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/refreshIndexTest.java
@@ -40,7 +40,7 @@ public class refreshIndexTest {
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");
 
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(mock(Socket.class));
 
     listener = mock(KuzzleResponseListener.class);

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/setAutoRefreshTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/setAutoRefreshTest.java
@@ -39,7 +39,7 @@ public class setAutoRefreshTest {
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");
 
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(mock(Socket.class));
 
     listener = mock(KuzzleResponseListener.class);

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/setJwtTokenTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/setJwtTokenTest.java
@@ -38,7 +38,7 @@ public class setJwtTokenTest {
     options.setDefaultIndex("testIndex");
 
     s = mock(Socket.class);
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(s);
 
     kuzzle = spy(kuzzle);

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/subscriptionsManagementTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/subscriptionsManagementTest.java
@@ -32,7 +32,7 @@ public class subscriptionsManagementTest {
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");
 
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(mock(Socket.class));
 
     listener = new KuzzleResponseListener<Object>() {

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/updateSelfTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/updateSelfTest.java
@@ -32,7 +32,7 @@ public class updateSelfTest {
 
   @Before
   public void setUp() throws URISyntaxException {
-    kuzzle = spy(new Kuzzle("http://localhost:7512"));
+    kuzzle = spy(new Kuzzle("localhost"));
     argument = ArgumentCaptor.forClass(Kuzzle.QueryArgs.class);
     listener = spy(new KuzzleResponseListener<JSONObject>() {
       @Override

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/whoAmiTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/whoAmiTest.java
@@ -37,7 +37,7 @@ public class whoAmiTest {
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");
 
-    kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(mock(Socket.class));
 
     listener = new KuzzleResponseListener<Object>() {

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/advancedSearchTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/advancedSearchTest.java
@@ -41,7 +41,7 @@ public class advancedSearchTest {
   public void setUp() throws URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
     kuzzle = spy(extended);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/constructorTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/constructorTest.java
@@ -35,7 +35,7 @@ public class constructorTest {
   public void setUp() throws URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/countTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/countTest.java
@@ -40,7 +40,7 @@ public class countTest {
   public void setUp() throws URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/createDocumentTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/createDocumentTest.java
@@ -40,7 +40,7 @@ public class createDocumentTest {
   public void setUp() throws URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/createTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/createTest.java
@@ -39,7 +39,7 @@ public class createTest {
   public void setUp() throws URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/deleteDocumentTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/deleteDocumentTest.java
@@ -40,7 +40,7 @@ public class deleteDocumentTest {
   public void setUp() throws URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/factoriesTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/factoriesTest.java
@@ -38,7 +38,7 @@ public class factoriesTest {
   public void setUp() throws URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/fetchAllDocumentsTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/fetchAllDocumentsTest.java
@@ -36,7 +36,7 @@ public class fetchAllDocumentsTest {
   public void setUp() throws URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/fetchDocument.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/fetchDocument.java
@@ -40,7 +40,7 @@ public class fetchDocument {
   public void setUp() throws URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/getMappingTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/getMappingTest.java
@@ -36,7 +36,7 @@ public class getMappingTest {
   public void setUp() throws URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
     kuzzle = spy(extended);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/publishMessageTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/publishMessageTest.java
@@ -37,7 +37,7 @@ public class publishMessageTest {
   public void setUp() throws URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/replaceDocumentTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/replaceDocumentTest.java
@@ -40,7 +40,7 @@ public class replaceDocumentTest {
   public void setUp() throws URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/subscribeTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/subscribeTest.java
@@ -37,7 +37,7 @@ public class subscribeTest {
   public void setUp() throws URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/truncateTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/truncateTest.java
@@ -39,7 +39,7 @@ public class truncateTest {
   public void setUp() throws URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/updateDocumentTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/updateDocumentTest.java
@@ -39,7 +39,7 @@ public class updateDocumentTest {
   public void setUp() throws URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDocument/constructorTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDocument/constructorTest.java
@@ -35,7 +35,7 @@ public class constructorTest {
   public void setUp() throws URISyntaxException, JSONException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setState(KuzzleStates.CONNECTED);
     k = spy(extended);
     doc = new KuzzleDocument(new KuzzleDataCollection(k, "index", "test"));

--- a/src/test/java/io/kuzzle/test/core/KuzzleDocument/deleteTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDocument/deleteTest.java
@@ -38,7 +38,7 @@ public class deleteTest {
   public void setUp() throws URISyntaxException, JSONException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setState(KuzzleStates.CONNECTED);
     k = spy(extended);
     doc = new KuzzleDocument(new KuzzleDataCollection(k, "index", "test"));

--- a/src/test/java/io/kuzzle/test/core/KuzzleDocument/publishTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDocument/publishTest.java
@@ -33,7 +33,7 @@ public class publishTest {
   public void setUp() throws URISyntaxException, JSONException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setState(KuzzleStates.CONNECTED);
     k = spy(extended);
     doc = new KuzzleDocument(new KuzzleDataCollection(k, "index", "test"));

--- a/src/test/java/io/kuzzle/test/core/KuzzleDocument/refreshTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDocument/refreshTest.java
@@ -40,7 +40,7 @@ public class refreshTest {
   public void setUp() throws URISyntaxException, JSONException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setState(KuzzleStates.CONNECTED);
     k = spy(extended);
     mockListener = mock(KuzzleResponseListener.class);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDocument/saveTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDocument/saveTest.java
@@ -38,7 +38,7 @@ public class saveTest {
   public void setUp() throws URISyntaxException, JSONException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setState(KuzzleStates.CONNECTED);
     k = spy(extended);
     mockListener = mock(KuzzleResponseListener.class);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDocument/serializeTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDocument/serializeTest.java
@@ -29,7 +29,7 @@ public class serializeTest {
   public void setUp() throws URISyntaxException, JSONException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setState(KuzzleStates.CONNECTED);
     k = spy(extended);
     doc = new KuzzleDocument(new KuzzleDataCollection(k, "index", "test"));

--- a/src/test/java/io/kuzzle/test/core/KuzzleDocument/subscribeTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDocument/subscribeTest.java
@@ -37,7 +37,7 @@ public class subscribeTest {
   public void setUp() throws URISyntaxException, JSONException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setState(KuzzleStates.CONNECTED);
     k = spy(extended);
     mockCollection = mock(KuzzleDataCollection.class);

--- a/src/test/java/io/kuzzle/test/core/KuzzleRoom/countTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleRoom/countTest.java
@@ -62,7 +62,7 @@ public class countTest {
         .put("result", new JSONObject())
         .put("requestId", "42");
     mockResponse.put("result", new JSONObject().put("channel", "channel").put("roomId", "42"));
-    k = spy(new KuzzleExtend("http://localhost:7512", null, null));
+    k = spy(new KuzzleExtend("localhost", null, null));
     k.setSocket(mock(Socket.class));
     k.setState(KuzzleStates.CONNECTED);
     when(k.getHeaders()).thenReturn(new JSONObject());
@@ -78,7 +78,7 @@ public class countTest {
   public void testCountWhileSubscribing() throws JSONException, URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
     extended = spy(extended);
@@ -140,7 +140,7 @@ public class countTest {
     JSONObject o = mock(JSONObject.class);
     when(o.put(any(String.class), any(Object.class))).thenReturn(new JSONObject());
 
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", null, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", null, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
     extended = spy(extended);

--- a/src/test/java/io/kuzzle/test/core/KuzzleRoom/notificationHandlerTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleRoom/notificationHandlerTest.java
@@ -94,7 +94,7 @@ public class notificationHandlerTest {
     options.setSubscribeToSelf(true);
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     Socket s = mock(Socket.class);
     extended.setSocket(s);
     extended.setState(KuzzleStates.CONNECTED);
@@ -110,7 +110,7 @@ public class notificationHandlerTest {
   public void testRenewOn() throws JSONException, URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     Socket s = mock(Socket.class);
     extended.setSocket(s);
     extended.setState(KuzzleStates.CONNECTED);
@@ -144,7 +144,7 @@ public class notificationHandlerTest {
 
   @Test
   public void testJwtTokenExpiredNotification() throws JSONException, URISyntaxException {
-    k = new Kuzzle("http://localhost:7512");
+    k = new Kuzzle("localhost");
     IKuzzleEventListener listener = spy(new IKuzzleEventListener() {
       @Override
       public void trigger(Object... args) {
@@ -166,7 +166,7 @@ public class notificationHandlerTest {
     KuzzleRoomOptions options = new KuzzleRoomOptions();
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     Socket s = mock(Socket.class);
     extended.setSocket(s);
     extended.setState(KuzzleStates.CONNECTED);

--- a/src/test/java/io/kuzzle/test/core/KuzzleRoom/renewTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleRoom/renewTest.java
@@ -69,7 +69,7 @@ public class renewTest {
     KuzzleOptions options = new KuzzleOptions();
     options.setConnect(Mode.MANUAL);
     Socket s = mock(Socket.class);
-    KuzzleExtend kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    KuzzleExtend kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setState(KuzzleStates.CONNECTED);
 
     final Kuzzle kuzzleSpy = spy(kuzzle);
@@ -107,7 +107,7 @@ public class renewTest {
   public void testRenewQueryException() throws JSONException, URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
     extended = spy(extended);
@@ -122,7 +122,7 @@ public class renewTest {
   public void testRenewException() throws JSONException, URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
     extended = spy(extended);
@@ -149,7 +149,7 @@ public class renewTest {
   public void testNoRenewal() throws JSONException, URISyntaxException {
     KuzzleOptions options = new KuzzleOptions();
     options.setConnect(Mode.MANUAL);
-    KuzzleExtend kuzzle = new KuzzleExtend("http://localhost:7512", options, null);
+    KuzzleExtend kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setState(KuzzleStates.CONNECTED);
     kuzzle.setSocket(mock(Socket.class));
 
@@ -177,7 +177,7 @@ public class renewTest {
   public void testRenewWhileSubscribing() throws JSONException, URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
     extended = spy(extended);

--- a/src/test/java/io/kuzzle/test/core/KuzzleRoom/unsubscribeTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleRoom/unsubscribeTest.java
@@ -67,7 +67,7 @@ public class unsubscribeTest {
     opts.setConnect(Mode.MANUAL);
     Socket s = mock(Socket.class);
 
-    KuzzleExtend kuzzle = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend kuzzle = new KuzzleExtend("localhost", opts, null);
     kuzzle.setState(KuzzleStates.CONNECTED);
     kuzzle.setSocket(s);
 
@@ -86,7 +86,7 @@ public class unsubscribeTest {
   public void testUnsubscribeWhileSubscribing() throws JSONException, URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
     extended = spy(extended);
@@ -122,7 +122,7 @@ public class unsubscribeTest {
     opts.setConnect(Mode.MANUAL);
     Socket s = mock(Socket.class);
 
-    KuzzleExtend kuzzle = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend kuzzle = new KuzzleExtend("localhost", opts, null);
     kuzzle.setState(KuzzleStates.CONNECTED);
     kuzzle.setSocket(s);
 
@@ -141,7 +141,7 @@ public class unsubscribeTest {
   public void testUnsubscribeException() throws URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
     extended = spy(extended);
@@ -155,7 +155,7 @@ public class unsubscribeTest {
   public void testUnsubscribeTask() throws URISyntaxException, JSONException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
     extended = spy(extended);
@@ -170,7 +170,7 @@ public class unsubscribeTest {
   public void testUnsubscribeTaskException() throws URISyntaxException {
     KuzzleOptions opts = new KuzzleOptions();
     opts.setConnect(Mode.MANUAL);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", opts, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
     extended = spy(extended);

--- a/src/test/java/io/kuzzle/test/listeners/KuzzleListenerTest.java
+++ b/src/test/java/io/kuzzle/test/listeners/KuzzleListenerTest.java
@@ -41,7 +41,7 @@ public class KuzzleListenerTest {
     KuzzleOptions options = new KuzzleOptions();
     options.setConnect(Mode.MANUAL);
     s = mock(Socket.class);
-    KuzzleExtend extended = new KuzzleExtend("http://localhost:7512", options, null);
+    KuzzleExtend extended = new KuzzleExtend("localhost", options, null);
     extended.setSocket(s);
     kuzzle = extended;
     kuzzleExtend = extended;


### PR DESCRIPTION
Changed the Kuzzle constructor according to the latest SDK specifications, taking a `host` name/address instead of an `url`, with an additional `port` option defaulted to 7512.
