### PR TITLE
Fix #70: improved coverage

### DIFF
--- a/src/main/java/io/kuzzle/sdk/core/KuzzleRoom.java
+++ b/src/main/java/io/kuzzle/sdk/core/KuzzleRoom.java
@@ -12,6 +12,7 @@ import java.util.TimerTask;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import io.kuzzle.sdk.enums.KuzzleEvent;
 import io.kuzzle.sdk.enums.Scope;
@@ -569,14 +570,21 @@ public class KuzzleRoom {
         threadPool.execute(r);
       }
 
-      this.queue.clear();
+      threadPool.shutdown();
+
+      try {
+        threadPool.awaitTermination(1, TimeUnit.SECONDS);
+      }
+      catch (InterruptedException e) {
+        // do nothing
+      }
+      finally {
+        this.queue.clear();
+      }
     }
   }
 
   private boolean isReady() {
-    if (this.kuzzle.state != KuzzleStates.CONNECTED || this.subscribing) {
-      return false;
-    }
-    return true;
+    return this.kuzzle.state == KuzzleStates.CONNECTED && !this.subscribing;
   }
 }

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/publishMessageTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/publishMessageTest.java
@@ -7,6 +7,8 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import java.net.URISyntaxException;
 
@@ -93,6 +95,25 @@ public class publishMessageTest {
     collection.publishMessage(doc, new KuzzleOptions());
     ArgumentCaptor argument = ArgumentCaptor.forClass(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class);
     verify(kuzzle, times(2)).query((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.capture(), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
+    assertEquals(((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.getValue()).controller, "write");
+    assertEquals(((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.getValue()).action, "publish");
+  }
+
+  @Test
+  public void testCallback() throws JSONException {
+    doAnswer(new Answer() {
+      @Override
+      public Object answer(InvocationOnMock invocation) throws Throwable {
+        ((OnQueryDoneListener)invocation.getArguments()[3]).onSuccess(new JSONObject().put("result", new JSONObject().put("acknowledged", true)));
+        ((OnQueryDoneListener) invocation.getArguments()[3]).onError(mock(JSONObject.class));
+        return null;
+      }
+    }).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
+
+    JSONObject message = new JSONObject().put("foo", "bar");
+    collection.publishMessage(message, listener);
+    ArgumentCaptor argument = ArgumentCaptor.forClass(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class);
+    verify(kuzzle, times(1)).query((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.capture(), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
     assertEquals(((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.getValue()).controller, "write");
     assertEquals(((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.getValue()).action, "publish");
   }


### PR DESCRIPTION
- The last merged [pull request](https://github.com/kuzzleio/sdk-android/pull/78) had a missing unit test. This PR fixes that.
- Fix a random concurrent access exception, due to KuzzleRoom's task queue being cleared before the tasks are finished
