### PR TITLE
KUZ-663: KuzzleDataCollection constructor signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,23 @@
 *__note:__ the # at the end of lines are the pull request numbers on GitHub*
 
+# Current
+
+## Breaking Changes
+
+* `KuzzleDataCollection` constructor signature has been changed from:  
+`KuzzleDataCollection(kuzzle, index, collection)`  
+ to:  
+`KuzzleDataCollection(kuzzle, collection, index)`  
+This has been done to make it on par with the `Kuzzle.dataCollectionFactory` method
+
+
 # 1.8.0
 
 * https://github.com/kuzzleio/sdk-android/releases/tag/1.8.0
 
 # 1.7.0
 
-* https://github.com/kuzzleio/sdk-android/releases/tag/1.7.0 
+* https://github.com/kuzzleio/sdk-android/releases/tag/1.7.0
 
 # 1.6.1
 

--- a/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
+++ b/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
@@ -532,7 +532,7 @@ public class Kuzzle {
 
     if (!this.collections.containsKey(collection)) {
       Map<String, KuzzleDataCollection> col = new ConcurrentHashMap<>();
-      col.put(collection, new KuzzleDataCollection(this, index, collection));
+      col.put(collection, new KuzzleDataCollection(this, collection, index));
       this.collections.put(index, col);
     }
     return this.collections.get(index).get(collection);

--- a/src/main/java/io/kuzzle/sdk/core/KuzzleDataCollection.java
+++ b/src/main/java/io/kuzzle/sdk/core/KuzzleDataCollection.java
@@ -33,10 +33,10 @@ public class KuzzleDataCollection {
    * or like a room for pub/sub messages.
    *
    * @param kuzzle     the kuzzle
-   * @param index      the index
    * @param collection the collection
+   * @param index      the index
    */
-  public KuzzleDataCollection(@NonNull final Kuzzle kuzzle, @NonNull final String index, @NonNull final String collection) {
+  public KuzzleDataCollection(@NonNull final Kuzzle kuzzle, @NonNull final String collection, @NonNull final String index) {
     if (kuzzle == null) {
       throw new IllegalArgumentException("KuzzleDataCollection: need a Kuzzle instance to initialize");
     }

--- a/src/main/java/io/kuzzle/sdk/responses/KuzzleNotificationResponse.java
+++ b/src/main/java/io/kuzzle/sdk/responses/KuzzleNotificationResponse.java
@@ -40,7 +40,7 @@ public class KuzzleNotificationResponse {
       this.scope = (object.isNull("scope") ? null : Scope.valueOf(object.getString("scope").toUpperCase()));
       this.users = (object.isNull("user") ? null : Users.valueOf(object.getString("user").toUpperCase()));
       if (!object.getJSONObject("result").isNull("_source")) {
-        this.document = new KuzzleDocument(new KuzzleDataCollection(kuzzle, this.index, this.collection), object.getJSONObject("result"));
+        this.document = new KuzzleDocument(new KuzzleDataCollection(kuzzle, this.collection, this.index), object.getJSONObject("result"));
         this.document.setId(this.result.getString("_id"));
       }
     } catch (JSONException e) {

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/connectionManagementTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/connectionManagementTest.java
@@ -128,8 +128,8 @@ public class connectionManagementTest {
     final Kuzzle kuzzleSpy = spy(extended);
 
     KuzzleRoom
-      room1 = new KuzzleRoom(new KuzzleDataCollection(kuzzleSpy, "index", "test")),
-      room2 = new KuzzleRoom(new KuzzleDataCollection(kuzzleSpy, "index", "test2"));
+      room1 = new KuzzleRoom(new KuzzleDataCollection(kuzzleSpy, "test", "index")),
+      room2 = new KuzzleRoom(new KuzzleDataCollection(kuzzleSpy, "test2", "index"));
 
     room1.renew(listener);
     room2.renew(listener);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/advancedSearchTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/advancedSearchTest.java
@@ -47,7 +47,7 @@ public class advancedSearchTest {
     kuzzle = spy(extended);
     when(kuzzle.getHeaders()).thenReturn(new JSONObject());
 
-    collection = new KuzzleDataCollection(kuzzle, "index", "test");
+    collection = new KuzzleDataCollection(kuzzle, "test", "index");
     listener = mock(KuzzleResponseListener.class);
   }
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/constructorTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/constructorTest.java
@@ -42,7 +42,7 @@ public class constructorTest {
     kuzzle = spy(extended);
     when(kuzzle.getHeaders()).thenReturn(new JSONObject());
 
-    collection = new KuzzleDataCollection(kuzzle, "index", "test");
+    collection = new KuzzleDataCollection(kuzzle, "test", "index");
     listener = mock(KuzzleResponseListener.class);
   }
 
@@ -85,17 +85,17 @@ public class constructorTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void shouldThrowIfNoIndexProvided() {
-    new KuzzleDataCollection(mock(Kuzzle.class), null, "foo");
+    new KuzzleDataCollection(mock(Kuzzle.class), "foo", null);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void shouldThrowIfNoCollectionProvided() {
-    new KuzzleDataCollection(mock(Kuzzle.class), "foo", null);
+    new KuzzleDataCollection(mock(Kuzzle.class), null, "foo");
   }
 
   @Test(expected = RuntimeException.class)
   public void testConstructorException() {
     doThrow(JSONException.class).when(kuzzle).getHeaders();
-    new KuzzleDataCollection(kuzzle, "foo", "collection");
+    new KuzzleDataCollection(kuzzle, "collections", "foo");
   }
 }

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/countTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/countTest.java
@@ -47,7 +47,7 @@ public class countTest {
     kuzzle = spy(extended);
     when(kuzzle.getHeaders()).thenReturn(new JSONObject());
 
-    collection = new KuzzleDataCollection(kuzzle, "index", "test");
+    collection = new KuzzleDataCollection(kuzzle, "test", "index");
     listener = mock(KuzzleResponseListener.class);
   }
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/createDocumentTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/createDocumentTest.java
@@ -47,7 +47,7 @@ public class createDocumentTest {
     kuzzle = spy(extended);
     when(kuzzle.getHeaders()).thenReturn(new JSONObject());
 
-    collection = new KuzzleDataCollection(kuzzle, "index", "test");
+    collection = new KuzzleDataCollection(kuzzle, "test", "index");
     listener = mock(KuzzleResponseListener.class);
   }
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/createTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/createTest.java
@@ -46,7 +46,7 @@ public class createTest {
     kuzzle = spy(extended);
     when(kuzzle.getHeaders()).thenReturn(new JSONObject());
 
-    collection = new KuzzleDataCollection(kuzzle, "index", "test");
+    collection = new KuzzleDataCollection(kuzzle, "test", "index");
     listener = mock(KuzzleResponseListener.class);
   }
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/factoriesTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/factoriesTest.java
@@ -45,7 +45,7 @@ public class factoriesTest {
     kuzzle = spy(extended);
     when(kuzzle.getHeaders()).thenReturn(new JSONObject());
 
-    collection = new KuzzleDataCollection(kuzzle, "index", "test");
+    collection = new KuzzleDataCollection(kuzzle, "test", "index");
     listener = mock(KuzzleResponseListener.class);
   }
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/fetchAllDocumentsTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/fetchAllDocumentsTest.java
@@ -43,7 +43,7 @@ public class fetchAllDocumentsTest {
     kuzzle = spy(extended);
     when(kuzzle.getHeaders()).thenReturn(new JSONObject());
 
-    collection = new KuzzleDataCollection(kuzzle, "index", "test");
+    collection = new KuzzleDataCollection(kuzzle, "test", "index");
     listener = mock(KuzzleResponseListener.class);
   }
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/fetchDocument.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/fetchDocument.java
@@ -47,7 +47,7 @@ public class fetchDocument {
     kuzzle = spy(extended);
     when(kuzzle.getHeaders()).thenReturn(new JSONObject());
 
-    collection = new KuzzleDataCollection(kuzzle, "index", "test");
+    collection = new KuzzleDataCollection(kuzzle, "test", "index");
     listener = mock(KuzzleResponseListener.class);
   }
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/getMappingTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/getMappingTest.java
@@ -42,7 +42,7 @@ public class getMappingTest {
     kuzzle = spy(extended);
     when(kuzzle.getHeaders()).thenReturn(new JSONObject());
 
-    collection = new KuzzleDataCollection(kuzzle, "index", "test");
+    collection = new KuzzleDataCollection(kuzzle, "test", "index");
     listener = mock(KuzzleResponseListener.class);
   }
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/publishMessageTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/publishMessageTest.java
@@ -45,7 +45,7 @@ public class publishMessageTest {
     kuzzle = spy(extended);
     when(kuzzle.getHeaders()).thenReturn(new JSONObject());
 
-    collection = new KuzzleDataCollection(kuzzle, "index", "test");
+    collection = new KuzzleDataCollection(kuzzle, "test", "index");
 
     MockitoAnnotations.initMocks(this);
   }

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/replaceDocumentTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/replaceDocumentTest.java
@@ -47,7 +47,7 @@ public class replaceDocumentTest {
     kuzzle = spy(extended);
     when(kuzzle.getHeaders()).thenReturn(new JSONObject());
 
-    collection = new KuzzleDataCollection(kuzzle, "index", "test");
+    collection = new KuzzleDataCollection(kuzzle, "test", "index");
     listener = mock(KuzzleResponseListener.class);
   }
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/subscribeTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/subscribeTest.java
@@ -44,7 +44,7 @@ public class subscribeTest {
     kuzzle = spy(extended);
     when(kuzzle.getHeaders()).thenReturn(new JSONObject());
 
-    collection = new KuzzleDataCollection(kuzzle, "index", "test");
+    collection = new KuzzleDataCollection(kuzzle, "test", "index");
     listener = mock(KuzzleResponseListener.class);
   }
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/truncateTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/truncateTest.java
@@ -46,7 +46,7 @@ public class truncateTest {
     kuzzle = spy(extended);
     when(kuzzle.getHeaders()).thenReturn(new JSONObject());
 
-    collection = new KuzzleDataCollection(kuzzle, "index", "test");
+    collection = new KuzzleDataCollection(kuzzle, "test", "index");
     listener = mock(KuzzleResponseListener.class);
   }
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/updateDocumentTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/updateDocumentTest.java
@@ -46,7 +46,7 @@ public class updateDocumentTest {
     kuzzle = spy(extended);
     when(kuzzle.getHeaders()).thenReturn(new JSONObject());
 
-    collection = new KuzzleDataCollection(kuzzle, "index", "test");
+    collection = new KuzzleDataCollection(kuzzle, "test", "index");
     listener = mock(KuzzleResponseListener.class);
   }
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataMapping/applyTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataMapping/applyTest.java
@@ -35,7 +35,7 @@ public class applyTest {
     k = mock(Kuzzle.class);
     when(k.getDefaultIndex()).thenReturn("index");
     when(k.getHeaders()).thenReturn(new JSONObject());
-    dataCollection = new KuzzleDataCollection(k, "index", "test");
+    dataCollection = new KuzzleDataCollection(k, "test", "index");
     dataMapping = new KuzzleDataMapping(dataCollection);
   }
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataMapping/constructorTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataMapping/constructorTest.java
@@ -28,13 +28,13 @@ public class constructorTest {
     k = mock(Kuzzle.class);
     when(k.getDefaultIndex()).thenReturn("index");
     when(k.getHeaders()).thenReturn(new JSONObject());
-    dataCollection = new KuzzleDataCollection(k, "index", "test");
+    dataCollection = new KuzzleDataCollection(k, "test", "index");
     dataMapping = new KuzzleDataMapping(dataCollection);
   }
 
   @Test(expected = RuntimeException.class)
   public void testConstructorException() {
-    KuzzleDataCollection fake = spy(new KuzzleDataCollection(k, "index", "test"));
+    KuzzleDataCollection fake = spy(new KuzzleDataCollection(k, "test", "index"));
     doThrow(JSONException.class).when(fake).getHeaders();
     dataMapping = new KuzzleDataMapping(fake);
   }

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataMapping/refreshTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataMapping/refreshTest.java
@@ -36,7 +36,7 @@ public class refreshTest {
     k = mock(Kuzzle.class);
     when(k.getDefaultIndex()).thenReturn("index");
     when(k.getHeaders()).thenReturn(new JSONObject());
-    dataCollection = new KuzzleDataCollection(k, "index", "test");
+    dataCollection = new KuzzleDataCollection(k, "test", "index");
     dataMapping = new KuzzleDataMapping(dataCollection);
   }
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataMapping/removeTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataMapping/removeTest.java
@@ -24,7 +24,7 @@ public class removeTest {
     k = mock(Kuzzle.class);
     when(k.getDefaultIndex()).thenReturn("index");
     when(k.getHeaders()).thenReturn(new JSONObject());
-    dataCollection = new KuzzleDataCollection(k, "index", "test");
+    dataCollection = new KuzzleDataCollection(k, "test", "index");
     dataMapping = new KuzzleDataMapping(dataCollection);
   }
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDocument/constructorTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDocument/constructorTest.java
@@ -38,7 +38,7 @@ public class constructorTest {
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setState(KuzzleStates.CONNECTED);
     k = spy(extended);
-    doc = new KuzzleDocument(new KuzzleDataCollection(k, "index", "test"));
+    doc = new KuzzleDocument(new KuzzleDataCollection(k, "test", "index"));
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -48,7 +48,7 @@ public class constructorTest {
 
   @Test
   public void testConstructor() throws JSONException {
-    doc = new KuzzleDocument(new KuzzleDataCollection(k, "index", "test"), "42");
+    doc = new KuzzleDocument(new KuzzleDataCollection(k, "test", "index"), "42");
     assertEquals(doc.getId(), "42");
   }
 
@@ -56,7 +56,7 @@ public class constructorTest {
   public void testCollection() throws JSONException {
     Kuzzle k = mock(Kuzzle.class);
     when(k.getHeaders()).thenReturn(new JSONObject());
-    KuzzleDataCollection collection = new KuzzleDataCollection(k, "index", "test");
+    KuzzleDataCollection collection = new KuzzleDataCollection(k, "test", "index");
     KuzzleDocument doc = new KuzzleDocument(collection);
     assertEquals(doc.getCollection(), collection.getCollection());
   }
@@ -66,7 +66,7 @@ public class constructorTest {
     JSONObject content = new JSONObject();
     content.put("foo", "bar");
 
-    doc = new KuzzleDocument(new KuzzleDataCollection(k, "index", "test"), content);
+    doc = new KuzzleDocument(new KuzzleDataCollection(k, "test", "index"), content);
     assertEquals(doc.getContent().getString("foo"), "bar");
   }
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDocument/deleteTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDocument/deleteTest.java
@@ -41,7 +41,7 @@ public class deleteTest {
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setState(KuzzleStates.CONNECTED);
     k = spy(extended);
-    doc = new KuzzleDocument(new KuzzleDataCollection(k, "index", "test"));
+    doc = new KuzzleDocument(new KuzzleDataCollection(k, "test", "index"));
   }
 
   @Test

--- a/src/test/java/io/kuzzle/test/core/KuzzleDocument/publishTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDocument/publishTest.java
@@ -36,7 +36,7 @@ public class publishTest {
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setState(KuzzleStates.CONNECTED);
     k = spy(extended);
-    doc = new KuzzleDocument(new KuzzleDataCollection(k, "index", "test"));
+    doc = new KuzzleDocument(new KuzzleDataCollection(k, "test", "index"));
   }
 
   @Test

--- a/src/test/java/io/kuzzle/test/core/KuzzleDocument/refreshTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDocument/refreshTest.java
@@ -44,7 +44,7 @@ public class refreshTest {
     extended.setState(KuzzleStates.CONNECTED);
     k = spy(extended);
     mockListener = mock(KuzzleResponseListener.class);
-    doc = new KuzzleDocument(new KuzzleDataCollection(k, "index", "test"));
+    doc = new KuzzleDocument(new KuzzleDataCollection(k, "test", "index"));
   }
 
   @Test

--- a/src/test/java/io/kuzzle/test/core/KuzzleDocument/saveTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDocument/saveTest.java
@@ -42,7 +42,7 @@ public class saveTest {
     extended.setState(KuzzleStates.CONNECTED);
     k = spy(extended);
     mockListener = mock(KuzzleResponseListener.class);
-    doc = new KuzzleDocument(new KuzzleDataCollection(k, "index", "test"));
+    doc = new KuzzleDocument(new KuzzleDataCollection(k, "test", "index"));
   }
 
   @Test

--- a/src/test/java/io/kuzzle/test/core/KuzzleDocument/serializeTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDocument/serializeTest.java
@@ -32,7 +32,7 @@ public class serializeTest {
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setState(KuzzleStates.CONNECTED);
     k = spy(extended);
-    doc = new KuzzleDocument(new KuzzleDataCollection(k, "index", "test"));
+    doc = new KuzzleDocument(new KuzzleDataCollection(k, "test", "index"));
   }
 
   @Test(expected = RuntimeException.class)

--- a/src/test/java/io/kuzzle/test/core/KuzzleDocument/subscribeTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDocument/subscribeTest.java
@@ -41,7 +41,7 @@ public class subscribeTest {
     extended.setState(KuzzleStates.CONNECTED);
     k = spy(extended);
     mockCollection = mock(KuzzleDataCollection.class);
-    doc = new KuzzleDocument(new KuzzleDataCollection(k, "index", "test"));
+    doc = new KuzzleDocument(new KuzzleDataCollection(k, "test", "index"));
   }
 
   @Test

--- a/src/test/java/io/kuzzle/test/core/KuzzleRoom/constructorTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleRoom/constructorTest.java
@@ -42,7 +42,7 @@ public class constructorTest {
     mockResponse.put("result", new JSONObject().put("channel", "channel").put("roomId", "42"));
     k = mock(Kuzzle.class);
     when(k.getHeaders()).thenReturn(new JSONObject());
-    room = new KuzzleRoomExtend(new KuzzleDataCollection(k, "index", "test"));
+    room = new KuzzleRoomExtend(new KuzzleDataCollection(k, "test", "index"));
   }
 
   @Test
@@ -51,7 +51,7 @@ public class constructorTest {
     meta.put("foo", "bar");
     KuzzleRoomOptions options = new KuzzleRoomOptions();
     options.setSubscribeToSelf(false);
-    KuzzleRoom room = new KuzzleRoom(new KuzzleDataCollection(k, "index", "test"), options);
+    KuzzleRoom room = new KuzzleRoom(new KuzzleDataCollection(k, "test", "index"), options);
     assertEquals(room.isSubscribeToSelf(), false);
     room.setSubscribeToSelf(true);
     assertEquals(room.isSubscribeToSelf(), true);
@@ -59,7 +59,7 @@ public class constructorTest {
 
   @Test(expected = RuntimeException.class)
   public void testConstructorException() {
-    KuzzleDataCollection fake = spy(new KuzzleDataCollection(k, "index", "test"));
+    KuzzleDataCollection fake = spy(new KuzzleDataCollection(k, "test", "index"));
     doThrow(JSONException.class).when(fake).getHeaders();
     room = new KuzzleRoomExtend(fake);
   }
@@ -113,7 +113,7 @@ public class constructorTest {
     meta.put("foo", "bar");
     KuzzleRoomOptions options = new KuzzleRoomOptions();
     options.setMetadata(meta);
-    KuzzleRoom room = new KuzzleRoom(new KuzzleDataCollection(k, "index", "test"), options);
+    KuzzleRoom room = new KuzzleRoom(new KuzzleDataCollection(k, "test", "index"), options);
     assertEquals(room.getMetadata().get("foo"), "bar");
     JSONObject meta2 = new JSONObject();
     meta2.put("oof", "rab");
@@ -129,7 +129,7 @@ public class constructorTest {
 
   @Test
   public void testCollection() {
-    KuzzleDataCollection collection = new KuzzleDataCollection(k, "index", "test");
+    KuzzleDataCollection collection = new KuzzleDataCollection(k, "test", "index");
     KuzzleRoom room = new KuzzleRoom(collection);
     assertEquals(room.getCollection(), collection.getCollection());
   }

--- a/src/test/java/io/kuzzle/test/core/KuzzleRoom/countTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleRoom/countTest.java
@@ -66,7 +66,7 @@ public class countTest {
     k.setSocket(mock(Socket.class));
     k.setState(KuzzleStates.CONNECTED);
     when(k.getHeaders()).thenReturn(new JSONObject());
-    room = new KuzzleRoomExtend(new KuzzleDataCollection(k, "index", "test"));
+    room = new KuzzleRoomExtend(new KuzzleDataCollection(k, "test", "index"));
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -82,7 +82,7 @@ public class countTest {
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
     extended = spy(extended);
-    room = new KuzzleRoomExtend(new KuzzleDataCollection(extended, "index", "test"));
+    room = new KuzzleRoomExtend(new KuzzleDataCollection(extended, "test", "index"));
     room.setRoomId("foobar");
     room.setSubscribing(true);
     room.count(spyListener);
@@ -144,7 +144,7 @@ public class countTest {
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
     extended = spy(extended);
-    room = new KuzzleRoomExtend(new KuzzleDataCollection(extended, "index", "test"));
+    room = new KuzzleRoomExtend(new KuzzleDataCollection(extended, "test", "index"));
     room.setRoomId("foobar");
 
     doAnswer(new Answer() {

--- a/src/test/java/io/kuzzle/test/core/KuzzleRoom/notificationHandlerTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleRoom/notificationHandlerTest.java
@@ -58,19 +58,19 @@ public class notificationHandlerTest {
     mockResponse.put("result", new JSONObject().put("channel", "channel").put("roomId", "42"));
     k = mock(Kuzzle.class);
     when(k.getHeaders()).thenReturn(new JSONObject());
-    room = new KuzzleRoomExtend(new KuzzleDataCollection(k, "index", "test"));
+    room = new KuzzleRoomExtend(new KuzzleDataCollection(k, "test", "index"));
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testCallAfterRenewWithNoResponse() {
-    KuzzleRoomExtend renew = new KuzzleRoomExtend(new KuzzleDataCollection(k, "index", "test"));
+    KuzzleRoomExtend renew = new KuzzleRoomExtend(new KuzzleDataCollection(k, "test", "index"));
     // Should throw an exception
     renew.callAfterRenew(null);
   }
 
   @Test
   public void testCallAfterRenewWithError() throws JSONException {
-    KuzzleRoomExtend renew = new KuzzleRoomExtend(new KuzzleDataCollection(k, "index", "test"));
+    KuzzleRoomExtend renew = new KuzzleRoomExtend(new KuzzleDataCollection(k, "test", "index"));
     JSONObject errorResponse = new JSONObject();
     errorResponse.put("error", "error");
     KuzzleResponseListener listener = mock(KuzzleResponseListener.class);
@@ -81,7 +81,7 @@ public class notificationHandlerTest {
 
   @Test
   public void testCallAfterRenew() throws JSONException {
-    KuzzleRoomExtend renew = new KuzzleRoomExtend(new KuzzleDataCollection(k, "index", "test"));
+    KuzzleRoomExtend renew = new KuzzleRoomExtend(new KuzzleDataCollection(k, "test", "index"));
     renew.setListener(listener);
     JSONObject mockResponse = new JSONObject().put("result", new JSONObject());
     mockResponse.put("requestId", "42");
@@ -99,7 +99,7 @@ public class notificationHandlerTest {
     extended.setSocket(s);
     extended.setState(KuzzleStates.CONNECTED);
     extended = spy(extended);
-    KuzzleRoomExtend renew = new KuzzleRoomExtend(new KuzzleDataCollection(extended, "index", "test"), options);
+    KuzzleRoomExtend renew = new KuzzleRoomExtend(new KuzzleDataCollection(extended, "test", "index"), options);
     renew.setListener(listener);
     extended.getRequestHistory().put("42", new Date());
     renew.callAfterRenew(mockNotif);
@@ -115,7 +115,7 @@ public class notificationHandlerTest {
     extended.setSocket(s);
     extended.setState(KuzzleStates.CONNECTED);
     extended = spy(extended);
-    room = new KuzzleRoomExtend(new KuzzleDataCollection(extended, "index", "collection"));
+    room = new KuzzleRoomExtend(new KuzzleDataCollection(extended, "collection", "index"));
     room.setRoomId("foobar");
     room = spy(room);
     doAnswer(new Answer() {
@@ -152,7 +152,7 @@ public class notificationHandlerTest {
       }
     });
     k.addListener(KuzzleEvent.jwtTokenExpired, listener);
-    KuzzleRoomExtend renew = new KuzzleRoomExtend(new KuzzleDataCollection(k, "index", "test"));
+    KuzzleRoomExtend renew = new KuzzleRoomExtend(new KuzzleDataCollection(k, "test", "index"));
     renew.setListener(mock(KuzzleResponseListener.class));
     JSONObject mockResponse = new JSONObject().put("result", new JSONObject());
     mockResponse.put("requestId", "42");
@@ -171,7 +171,7 @@ public class notificationHandlerTest {
     extended.setSocket(s);
     extended.setState(KuzzleStates.CONNECTED);
     extended = spy(extended);
-    KuzzleRoomExtend renew = new KuzzleRoomExtend(new KuzzleDataCollection(extended, "index", "test"), options);
+    KuzzleRoomExtend renew = new KuzzleRoomExtend(new KuzzleDataCollection(extended, "test", "index"), options);
     mockNotif = spy(mockNotif);
     doThrow(JSONException.class).when(mockNotif).isNull(any(String.class));
     renew.setListener(listener);

--- a/src/test/java/io/kuzzle/test/core/KuzzleRoom/renewTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleRoom/renewTest.java
@@ -61,7 +61,7 @@ public class renewTest {
     mockResponse.put("result", new JSONObject().put("channel", "channel").put("roomId", "42"));
     k = mock(Kuzzle.class);
     when(k.getHeaders()).thenReturn(new JSONObject());
-    room = new KuzzleRoomExtend(new KuzzleDataCollection(k, "index", "test"));
+    room = new KuzzleRoomExtend(new KuzzleDataCollection(k, "text", "index"));
 
     MockitoAnnotations.initMocks(this);
   }
@@ -80,7 +80,7 @@ public class renewTest {
     kuzzle.setState(KuzzleStates.CONNECTED);
 
     final Kuzzle kuzzleSpy = spy(kuzzle);
-    KuzzleRoom testRoom = new KuzzleRoom(new KuzzleDataCollection(kuzzleSpy, "index", "collection"));
+    KuzzleRoom testRoom = new KuzzleRoom(new KuzzleDataCollection(kuzzleSpy, "collection", "index"));
 
     doAnswer(new Answer() {
       @Override
@@ -118,7 +118,7 @@ public class renewTest {
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
     extended = spy(extended);
-    room = new KuzzleRoomExtend(new KuzzleDataCollection(extended, "index", "collection"));
+    room = new KuzzleRoomExtend(new KuzzleDataCollection(extended, "collection", "index"));
     room.setRoomId("foobar");
     room = spy(room);
     doThrow(JSONException.class).when(extended).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
@@ -134,7 +134,7 @@ public class renewTest {
     extended.setState(KuzzleStates.CONNECTED);
     extended = spy(extended);
     doThrow(JSONException.class).when(extended).deletePendingSubscription(any(String.class));
-    room = new KuzzleRoomExtend(new KuzzleDataCollection(extended, "index", "collection"));
+    room = new KuzzleRoomExtend(new KuzzleDataCollection(extended, "collection", "index"));
     room.setRoomId("foobar");
     room = spy(room);
     doAnswer(new Answer() {
@@ -161,7 +161,7 @@ public class renewTest {
     kuzzle.setSocket(mock(Socket.class));
 
     final Kuzzle kuzzleSpy = spy(kuzzle);
-    KuzzleRoomExtend testRoom = new KuzzleRoomExtend(new KuzzleDataCollection(kuzzleSpy, "index", "collection"));
+    KuzzleRoomExtend testRoom = new KuzzleRoomExtend(new KuzzleDataCollection(kuzzleSpy, "collection", "index"));
     testRoom.setRoomId("foobar");
     doAnswer(new Answer() {
       @Override
@@ -188,7 +188,7 @@ public class renewTest {
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
     extended = spy(extended);
-    room = new KuzzleRoomExtend(new KuzzleDataCollection(extended, "index", "test"));
+    room = new KuzzleRoomExtend(new KuzzleDataCollection(extended, "test", "index"));
     room.setRoomId("foobar");
     room.setSubscribing(true);
     room.renew(listener);

--- a/src/test/java/io/kuzzle/test/core/KuzzleRoom/unsubscribeTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleRoom/unsubscribeTest.java
@@ -57,7 +57,7 @@ public class unsubscribeTest {
     mockResponse.put("result", new JSONObject().put("channel", "channel").put("roomId", "42"));
     k = mock(Kuzzle.class);
     when(k.getHeaders()).thenReturn(new JSONObject());
-    room = new KuzzleRoomExtend(new KuzzleDataCollection(k, "index", "test"));
+    room = new KuzzleRoomExtend(new KuzzleDataCollection(k, "test", "index"));
   }
 
 
@@ -72,7 +72,7 @@ public class unsubscribeTest {
     kuzzle.setSocket(s);
 
     kuzzle = spy(kuzzle);
-    room = new KuzzleRoomExtend(new KuzzleDataCollection(kuzzle, "index", "test"));
+    room = new KuzzleRoomExtend(new KuzzleDataCollection(kuzzle, "test", "index"));
     room.setRoomId("42");
     room.superUnsubscribe();
     assertEquals(room.getRoomId(), null);
@@ -90,7 +90,7 @@ public class unsubscribeTest {
     extended.setSocket(mock(Socket.class));
     extended.setState(KuzzleStates.CONNECTED);
     extended = spy(extended);
-    room = new KuzzleRoomExtend(new KuzzleDataCollection(extended, "index", "test"));
+    room = new KuzzleRoomExtend(new KuzzleDataCollection(extended, "test", "index"));
     room.setRoomId("foobar");
     room.setSubscribing(true);
     room.superUnsubscribe();
@@ -129,7 +129,7 @@ public class unsubscribeTest {
     kuzzle = spy(kuzzle);
     kuzzle.getPendingSubscriptions().put("42", mock(KuzzleRoom.class));
 
-    room = new KuzzleRoomExtend(new KuzzleDataCollection(kuzzle, "index", "test"));
+    room = new KuzzleRoomExtend(new KuzzleDataCollection(kuzzle, "test", "index"));
     room.setRoomId("42");
     room.superUnsubscribe();
 
@@ -146,7 +146,7 @@ public class unsubscribeTest {
     extended.setState(KuzzleStates.CONNECTED);
     extended = spy(extended);
     doThrow(JSONException.class).when(extended).getSocket();
-    room = new KuzzleRoomExtend(new KuzzleDataCollection(extended, "index", "test"));
+    room = new KuzzleRoomExtend(new KuzzleDataCollection(extended, "test", "index"));
     room.setRoomId("foobar");
     room.superUnsubscribe();
   }
@@ -160,7 +160,7 @@ public class unsubscribeTest {
     extended.setState(KuzzleStates.CONNECTED);
     extended = spy(extended);
 
-    room = new KuzzleRoomExtend(new KuzzleDataCollection(extended, "index", "test"));
+    room = new KuzzleRoomExtend(new KuzzleDataCollection(extended, "test", "index"));
     room.setRoomId("foobar");
     room.unsubscribeTask(new Timer(), room.getRoomId(), new JSONObject()).run();
     verify(extended).query(any(Kuzzle.QueryArgs.class), any(JSONObject.class), any(KuzzleOptions.class), any(OnQueryDoneListener.class));
@@ -175,7 +175,7 @@ public class unsubscribeTest {
     extended.setState(KuzzleStates.CONNECTED);
     extended = spy(extended);
     doThrow(JSONException.class).when(extended).getPendingSubscriptions();
-    room = new KuzzleRoomExtend(new KuzzleDataCollection(extended, "index", "test"));
+    room = new KuzzleRoomExtend(new KuzzleDataCollection(extended, "test", "index"));
     room.setRoomId("foobar");
     room.unsubscribeTask(new Timer(), room.getRoomId(), new JSONObject()).run();
   }

--- a/src/test/java/io/kuzzle/test/testUtils/KuzzleDataCollectionExtend.java
+++ b/src/test/java/io/kuzzle/test/testUtils/KuzzleDataCollectionExtend.java
@@ -11,7 +11,7 @@ import io.kuzzle.sdk.listeners.KuzzleResponseListener;
 
 public class KuzzleDataCollectionExtend extends KuzzleDataCollection {
   public KuzzleDataCollectionExtend(@NonNull final Kuzzle kuzzle, @NonNull final String index, @NonNull final String collection) {
-    super(kuzzle, index, collection);
+    super(kuzzle, collection, index);
   }
 
   public KuzzleDataCollection deleteDocument(final String documentId, final JSONObject filter, final KuzzleOptions options, final KuzzleResponseListener<String> listener, final KuzzleResponseListener<String[]> listener2) {


### PR DESCRIPTION
For the sake of consistency, the KuzzleDataCollection constructor has been changed so that its signature matches `Kuzzle.dataCollectionFactory`
