### PR TITLE
KUZ-683 allow changing host

### DIFF
--- a/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
+++ b/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
@@ -76,9 +76,9 @@ public class Kuzzle {
    */
   protected JSONObject metadata;
   /**
-   * The target Kuzzle URL
+   * The target Kuzzle host
    */
-  protected String url;
+  protected String host;
   /**
    * Target Kuzzle network port
    */
@@ -240,6 +240,8 @@ public class Kuzzle {
       throw new IllegalArgumentException("Host name/address can't be empty");
     }
 
+    this.host = host;
+
     KuzzleOptions opt = (options != null ? options : new KuzzleOptions());
 
     this.autoQueue = opt.isAutoQueue();
@@ -255,12 +257,7 @@ public class Kuzzle {
     this.reconnectionDelay = opt.getReconnectionDelay();
     this.replayInterval = opt.getReplayInterval();
 
-    this.url = "http://" + host + ":" + this.port;
     this.connectionCallback = connectionCallback;
-
-    if (socket == null) {
-      socket = createSocket();
-    }
 
     if (opt.getOfflineMode() == Mode.AUTO) {
       this.autoReconnect = this.autoQueue = this.autoReplay = this.autoResubscribe = true;
@@ -387,7 +384,7 @@ public class Kuzzle {
   }
 
   /**
-   * Connects to a Kuzzle instance using the provided URL.
+   * Connects to a Kuzzle instance using the provided host and port.
    *
    * @return kuzzle kuzzle
    * @throws URISyntaxException the uri syntax exception
@@ -400,9 +397,11 @@ public class Kuzzle {
       }
     }
 
-    if (this.socket == null) {
-      this.socket = createSocket();
+    if (this.socket != null) {
+      this.disconnect();
     }
+
+    this.socket = createSocket();
 
     Kuzzle.this.state = KuzzleStates.CONNECTING;
 
@@ -1480,12 +1479,12 @@ public class Kuzzle {
     this.emitEvent(KuzzleEvent.reconnected);
   }
 
-  private Socket createSocket() throws URISyntaxException {
+  protected Socket createSocket() throws URISyntaxException {
     IO.Options opt = new IO.Options();
     opt.forceNew = true;
     opt.reconnection = this.autoReconnect;
     opt.reconnectionDelay = this.reconnectionDelay;
-    return IO.socket(this.url, opt);
+    return IO.socket("http://" + host + ":" + this.port, opt);
   }
 
   /**
@@ -1734,10 +1733,41 @@ public class Kuzzle {
   }
 
   /**
+   * Sets the network port
+   *
+   * @param port the new port
+   * @return this
+   */
+  public Kuzzle setPort(int port) {
+    this.port = port;
+    return this;
+  }
+
+  /**
+   * Gets the kuzzle host
+   *
+   * @returns string
+   */
+  public String getHost() {
+    return this.host;
+  }
+
+  /**
+   * Sets the kuzzle host instance
+   *
+   * @param host the new host to set
+   * @return
+   */
+  public Kuzzle setHost(String host) {
+    this.host = host;
+    return this;
+  }
+
+  /**
    * Sets auto replay.
    *
    * @param autoReplay the auto replay
-   * @return the auto replay
+   * @return this
    */
   public Kuzzle setAutoReplay(boolean autoReplay) {
     this.autoReplay = autoReplay;

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/connectionManagementTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/connectionManagementTest.java
@@ -180,7 +180,10 @@ public class connectionManagementTest {
     kuzzle = spy(kuzzle);
 
     kuzzle.connect();
-    verify(kuzzle, times(1)).disconnect();
+
+    // since "connect" is called 2 times with a socket set, disconnect
+    // is called each time
+    verify(kuzzle, times(2)).disconnect();
   }
 
   @Test

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/constructorTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/constructorTest.java
@@ -269,4 +269,22 @@ public class constructorTest {
   public void testGetPort() {
     assertEquals(kuzzle.getPort(), 12345);
   }
+
+  @Test
+  public void testSetPort() {
+    kuzzle = spy(kuzzle);
+    kuzzle.setPort(1234);
+    assertEquals(kuzzle.getPort(), 1234);
+  }
+
+  @Test
+  public void testGetHost() {
+    assertEquals("localhost", kuzzle.getHost());
+  }
+
+  @Test public void testSetHost() {
+    kuzzle = spy(kuzzle);
+    kuzzle.setHost("foobar");
+    assertEquals("foobar", kuzzle.getHost());
+  }
 }

--- a/src/test/java/io/kuzzle/test/core/KuzzleDocument/deleteTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDocument/deleteTest.java
@@ -19,6 +19,7 @@ import io.kuzzle.sdk.listeners.KuzzleResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.KuzzleStates;
 import io.kuzzle.test.testUtils.KuzzleExtend;
+import io.socket.client.Socket;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -40,6 +41,7 @@ public class deleteTest {
     opts.setConnect(Mode.MANUAL);
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setState(KuzzleStates.CONNECTED);
+    extended.setSocket(mock(Socket.class));
     k = spy(extended);
     doc = new KuzzleDocument(new KuzzleDataCollection(k, "test", "index"));
   }

--- a/src/test/java/io/kuzzle/test/core/KuzzleDocument/publishTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDocument/publishTest.java
@@ -16,11 +16,13 @@ import io.kuzzle.sdk.enums.Mode;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.KuzzleStates;
 import io.kuzzle.test.testUtils.KuzzleExtend;
+import io.socket.client.Socket;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -35,6 +37,7 @@ public class publishTest {
     opts.setConnect(Mode.MANUAL);
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setState(KuzzleStates.CONNECTED);
+    extended.setSocket(mock(Socket.class));
     k = spy(extended);
     doc = new KuzzleDocument(new KuzzleDataCollection(k, "test", "index"));
   }

--- a/src/test/java/io/kuzzle/test/core/KuzzleDocument/refreshTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDocument/refreshTest.java
@@ -19,6 +19,7 @@ import io.kuzzle.sdk.listeners.KuzzleResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.KuzzleStates;
 import io.kuzzle.test.testUtils.KuzzleExtend;
+import io.socket.client.Socket;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -42,6 +43,7 @@ public class refreshTest {
     opts.setConnect(Mode.MANUAL);
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setState(KuzzleStates.CONNECTED);
+    extended.setSocket(mock(Socket.class));
     k = spy(extended);
     mockListener = mock(KuzzleResponseListener.class);
     doc = new KuzzleDocument(new KuzzleDataCollection(k, "test", "index"));

--- a/src/test/java/io/kuzzle/test/core/KuzzleDocument/saveTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDocument/saveTest.java
@@ -19,6 +19,7 @@ import io.kuzzle.sdk.listeners.KuzzleResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.KuzzleStates;
 import io.kuzzle.test.testUtils.KuzzleExtend;
+import io.socket.client.Socket;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -40,6 +41,7 @@ public class saveTest {
     opts.setConnect(Mode.MANUAL);
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setState(KuzzleStates.CONNECTED);
+    extended.setSocket(mock(Socket.class));
     k = spy(extended);
     mockListener = mock(KuzzleResponseListener.class);
     doc = new KuzzleDocument(new KuzzleDataCollection(k, "test", "index"));

--- a/src/test/java/io/kuzzle/test/core/KuzzleDocument/subscribeTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDocument/subscribeTest.java
@@ -18,6 +18,7 @@ import io.kuzzle.sdk.listeners.KuzzleResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.KuzzleStates;
 import io.kuzzle.test.testUtils.KuzzleExtend;
+import io.socket.client.Socket;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -39,6 +40,7 @@ public class subscribeTest {
     opts.setConnect(Mode.MANUAL);
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setState(KuzzleStates.CONNECTED);
+    extended.setSocket(mock(Socket.class));
     k = spy(extended);
     mockCollection = mock(KuzzleDataCollection.class);
     doc = new KuzzleDocument(new KuzzleDataCollection(k, "test", "index"));

--- a/src/test/java/io/kuzzle/test/core/KuzzleRoom/renewTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleRoom/renewTest.java
@@ -78,6 +78,7 @@ public class renewTest {
     Socket s = mock(Socket.class);
     KuzzleExtend kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setState(KuzzleStates.CONNECTED);
+    kuzzle.setSocket(s);
 
     final Kuzzle kuzzleSpy = spy(kuzzle);
     KuzzleRoom testRoom = new KuzzleRoom(new KuzzleDataCollection(kuzzleSpy, "collection", "index"));

--- a/src/test/java/io/kuzzle/test/testUtils/KuzzleExtend.java
+++ b/src/test/java/io/kuzzle/test/testUtils/KuzzleExtend.java
@@ -24,6 +24,7 @@ import io.socket.client.Socket;
 import static org.mockito.Mockito.spy;
 
 public class KuzzleExtend extends Kuzzle {
+  protected Socket savedSocket = null;
 
   public KuzzleResponseListener loginCallback;
 
@@ -46,7 +47,7 @@ public class KuzzleExtend extends Kuzzle {
   }
 
   public void setSocket(Socket s) {
-    this.socket = s;
+    this.socket = this.savedSocket = s;
   }
 
   public void setListener(KuzzleResponseListener listener) {
@@ -56,6 +57,11 @@ public class KuzzleExtend extends Kuzzle {
 
   public Kuzzle deleteSubscription(final String roomId, final String id) {
     return super.deleteSubscription(roomId, id);
+  }
+
+
+  protected Socket createSocket() throws URISyntaxException {
+    return this.savedSocket != null ? this.savedSocket : super.createSocket();
   }
 
   /**


### PR DESCRIPTION
- `host` and `port` properties are now updatable
- add missing getter function for `host` and a new setter one
- add a new setter for `port`
- force a disconnection when `connect` is invoked and if a socket is already active
