### PR TITLE
moved the JWT token where Kuzzle RC8 expects it

### DIFF
--- a/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
+++ b/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
@@ -1109,10 +1109,10 @@ public class Kuzzle {
       QueryArgs args = new QueryArgs();
       args.controller = "auth";
       args.action = "logout";
-      return this.query(args, new JSONObject(), options, new OnQueryDoneListener() {
+
+      this.query(args, new JSONObject(), options, new OnQueryDoneListener() {
         @Override
         public void onSuccess(JSONObject object) {
-          Kuzzle.this.jwtToken = null;
           if (listener != null) {
             listener.onSuccess(null);
           }
@@ -1128,6 +1128,9 @@ public class Kuzzle {
     } catch (JSONException e) {
       throw new RuntimeException(e);
     }
+
+    Kuzzle.this.jwtToken = null;
+    return this;
   }
 
   /**
@@ -1281,11 +1284,7 @@ public class Kuzzle {
      * a developer simply wish to verify his token
      */
     if (this.jwtToken != null && !(queryArgs.controller.equals("auth") && queryArgs.action.equals("checkToken"))) {
-      if (!object.has("headers")) {
-        object.put("headers", new JSONObject());
-      }
-
-      object.getJSONObject("headers").put("authorization", "Bearer " + this.jwtToken);
+      object.put("jwt", this.jwtToken);
     }
 
     if (this.state == KuzzleStates.CONNECTED || (options != null && !options.isQueuable())) {

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/queryTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/queryTest.java
@@ -150,9 +150,7 @@ public class queryTest {
     assertEquals(request.has("index"), false);
     assertEquals(request.has("collection"), false);
     assertNotNull(request.getString("requestId"));
-
-    String token = request.getJSONObject("headers").getString("authorization");
-    assertEquals(token, "Bearer token");
+    assertEquals(request.getString("jwt"), "token");
   }
 
   @Test


### PR DESCRIPTION
* The JWT Token is now at the root of the request object sent to Kuzzle, in the `jwt` property
* When logging out, the jwt token is immediately removed from the SDK, without waiting for Kuzzle to respond