### PR TITLE
Fix 106: offline mode does not reject

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ android:
         - build-tools-23.0.2
         - platform-tools
         - android-23
+        - extra-android-support
 
 before_install:
     - export TERM=dumb

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:2.1.2'
-        classpath 'com.dicedmelon.gradle:jacoco-android:0.1.0'
+        classpath 'com.dicedmelon.gradle:jacoco-android:0.1.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
     }
 }
@@ -21,7 +21,7 @@ android {
     buildToolsVersion '23.0.2'
     defaultConfig {
         minSdkVersion 10
-        targetSdkVersion 10
+        targetSdkVersion 23
         versionCode 1
         versionName version
     }
@@ -48,8 +48,9 @@ repositories {
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:+'
+    compile fileTree(include: ['*.jar'], dir: 'lib' +
+            's')
+    compile 'com.android.support:appcompat-v7:23.0.0'
     compile 'io.socket:socket.io-client:0.6.2'
     testCompile 'junit:junit:4.12'
     testCompile 'org.hamcrest:hamcrest-junit:2.0.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -48,8 +48,7 @@ repositories {
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'lib' +
-            's')
+    compile fileTree(include: ['*.jar'], dir: 'libs')
     compile 'com.android.support:appcompat-v7:23.0.0'
     compile 'io.socket:socket.io-client:0.6.2'
     testCompile 'junit:junit:4.12'

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ repositories {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:23.0.0'
+    compile 'com.android.support:appcompat-v7:23.0.+'
     compile 'io.socket:socket.io-client:0.6.2'
     testCompile 'junit:junit:4.12'
     testCompile 'org.hamcrest:hamcrest-junit:2.0.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,8 @@ repositories {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:23.0.+'
+    // Temporary using v21, until Travis supports v23+
+    compile 'com.android.support:appcompat-v7:21.+'
     compile 'io.socket:socket.io-client:0.6.2'
     testCompile 'junit:junit:4.12'
     testCompile 'org.hamcrest:hamcrest-junit:2.0.0.0'

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  range: "80...100"
+
+  status:
+    project:
+      default:
+        threshold: 1
+
+    patch:
+      default:
+        branches:
+          - master

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/getAllStatisticsTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/getAllStatisticsTest.java
@@ -14,8 +14,10 @@ import java.util.Iterator;
 
 import io.kuzzle.sdk.core.Options;
 import io.kuzzle.sdk.enums.Mode;
+import io.kuzzle.sdk.enums.State;
 import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
+import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleExtend;
 import io.kuzzle.test.testUtils.QueryArgsHelper;
 import io.socket.client.Socket;
@@ -42,6 +44,7 @@ public class getAllStatisticsTest {
 
     kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(mock(Socket.class));
+    kuzzle.setState(States.CONNECTED);
 
     listener = new ResponseListener<Object>() {
       @Override
@@ -171,6 +174,7 @@ public class getAllStatisticsTest {
       @Override
       public void onError(JSONObject error) {
         try {
+          System.out.println(error.toString());
           assertEquals(error.get("error"), "rorre");
         } catch (JSONException e) {
           throw new RuntimeException(e);


### PR DESCRIPTION
Fix #106

Instead of silently discarding requests during offline mode with no queue option activated, it now explicitly rejects them, allowing clients to catch the error and act accordingly.

Other bugfix: it was also silently discarding requests during offline mode, if queue option is false but the request itself was passed with the `queuable` option set to true

Unrelated: forces appcompat version to 23.0.0 to avoid compatibility issues while compiling the SDK with gradle