### PR TITLE
Collection.createDocument: rename the updateIfExist option

### DIFF
--- a/src/main/java/io/kuzzle/sdk/core/Collection.java
+++ b/src/main/java/io/kuzzle/sdk/core/Collection.java
@@ -422,7 +422,7 @@ public class Collection {
     String action = "create";
     JSONObject data = document.serialize();
 
-    if (options != null && options.getIfExists().equals("replace")) {
+    if (options != null && options.getIfExist().equals("replace")) {
       action = "createOrReplace";
     }
 

--- a/src/main/java/io/kuzzle/sdk/core/Collection.java
+++ b/src/main/java/io/kuzzle/sdk/core/Collection.java
@@ -419,8 +419,12 @@ public class Collection {
    * @return the kuzzle data collection
    */
   public Collection createDocument(final Document document, final Options options, final ResponseListener<Document> listener) {
-    String action = (options != null && options.isUpdateIfExists()) ? "createOrReplace" : "create";
+    String action = "create";
     JSONObject data = document.serialize();
+
+    if (options != null && options.getIfExists().equals("replace")) {
+      action = "createOrReplace";
+    }
 
     this.kuzzle.addHeaders(data, this.getHeaders());
 

--- a/src/main/java/io/kuzzle/sdk/core/Options.java
+++ b/src/main/java/io/kuzzle/sdk/core/Options.java
@@ -19,7 +19,7 @@ public class Options {
   private int queueMaxSize = 500;
   private int queueTTL = 120000;
   private long reconnectionDelay = 1000;
-  private String ifExists = "error";
+  private String ifExist = "error";
   private Mode connect = Mode.AUTO;
   private Mode offlineMode = Mode.MANUAL;
   private int replayInterval = 10;
@@ -79,8 +79,8 @@ public class Options {
    *
    * @return value of the ifExists parameter
    */
-  public String getIfExists() {
-    return ifExists;
+  public String getIfExist() {
+    return ifExist;
   }
 
   /**
@@ -90,12 +90,12 @@ public class Options {
    * @return the update if exists
    * @throws
    */
-  public Options setIfExists(String value) {
+  public Options setIfExist(String value) {
     if (value != "error" && value != "replace") {
       throw new IllegalArgumentException("Invalid value for option 'ifExists': " + value);
     }
 
-    this.ifExists = value;
+    this.ifExist = value;
     return this;
   }
 

--- a/src/main/java/io/kuzzle/sdk/core/Options.java
+++ b/src/main/java/io/kuzzle/sdk/core/Options.java
@@ -19,7 +19,7 @@ public class Options {
   private int queueMaxSize = 500;
   private int queueTTL = 120000;
   private long reconnectionDelay = 1000;
-  private boolean updateIfExists = false;
+  private String ifExists = "error";
   private Mode connect = Mode.AUTO;
   private Mode offlineMode = Mode.MANUAL;
   private int replayInterval = 10;
@@ -77,20 +77,25 @@ public class Options {
   /**
    * Is update if exists boolean.
    *
-   * @return the boolean
+   * @return value of the ifExists parameter
    */
-  public boolean isUpdateIfExists() {
-    return updateIfExists;
+  public String getIfExists() {
+    return ifExists;
   }
 
   /**
    * Sets update if exists.
    *
-   * @param updateIfExists the update if exists
+   * @param value the update if exists
    * @return the update if exists
+   * @throws
    */
-  public Options setUpdateIfExists(boolean updateIfExists) {
-    this.updateIfExists = updateIfExists;
+  public Options setIfExists(String value) {
+    if (value != "error" && value != "replace") {
+      throw new IllegalArgumentException("Invalid value for option 'ifExists': " + value);
+    }
+
+    this.ifExists = value;
     return this;
   }
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/createDocumentTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/createDocumentTest.java
@@ -56,7 +56,7 @@ public class createDocumentTest {
     Document doc = mock(Document.class);
     JSONObject content = new JSONObject();
     String id = "foo";
-    Options opts = mock(Options.class);
+    Options opts = new Options();
 
     collection = spy(collection);
 
@@ -88,7 +88,7 @@ public class createDocumentTest {
   public void testCreateDocumentIllegalIfExistValue() {
     Options opts = new Options();
 
-    opts.setIfExists("foobar");
+    opts.setIfExist("foobar");
   }
 
   @Test(expected = RuntimeException.class)
@@ -135,7 +135,7 @@ public class createDocumentTest {
     Document doc = new Document(collection);
     doc.setContent("foo", "bar");
     Options options = new Options();
-    options.setIfExists("replace");
+    options.setIfExist("replace");
     collection.createDocument(doc, options);
     ArgumentCaptor argument = ArgumentCaptor.forClass(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class);
     verify(kuzzle, times(1)).query((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.capture(), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/createDocumentTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/createDocumentTest.java
@@ -84,6 +84,13 @@ public class createDocumentTest {
     collection.createDocument(mock(Document.class), listener);
   }
 
+  @Test(expected = IllegalArgumentException.class)
+  public void testCreateDocumentIllegalIfExistValue() {
+    Options opts = new Options();
+
+    opts.setIfExists("foobar");
+  }
+
   @Test(expected = RuntimeException.class)
   public void testCreateDocumentException() throws JSONException {
     doAnswer(new Answer() {
@@ -128,7 +135,7 @@ public class createDocumentTest {
     Document doc = new Document(collection);
     doc.setContent("foo", "bar");
     Options options = new Options();
-    options.setUpdateIfExists(true);
+    options.setIfExists("replace");
     collection.createDocument(doc, options);
     ArgumentCaptor argument = ArgumentCaptor.forClass(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class);
     verify(kuzzle, times(1)).query((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.capture(), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));


### PR DESCRIPTION
# Description

The `Collection.createDocument` method accepts a `updateIfExist` option.
Since this option really replaces the document if it already exists, it is dangerously confusing.

This PR change this option name to `ifExist` in the `Options` class, with appropriate getter and setter.
When using the setter method, the only accepted values are: `error` (default) or `replace`
If an invalid value is provided, the method throws an `InvalidArgumentException` exception.

# Solved issue

#112 
