### PR TITLE
Add Security:replaceUser support

### DIFF
--- a/src/main/java/io/kuzzle/sdk/security/Security.java
+++ b/src/main/java/io/kuzzle/sdk/security/Security.java
@@ -999,6 +999,83 @@ public class Security {
   }
 
   /**
+   * Replaces an existing user in Kuzzle.
+   *
+   * @param id       - ID of the user to replace
+   * @param content  - Should contain a 'profileIds' attribute with the profile IDs
+   * @param options  - Optional arguments
+   * @param listener - Callback listener
+   * @throws JSONException the json exception
+   */
+  public void replaceUser(@NonNull final String id, @NonNull final JSONObject content, final Options options, final ResponseListener<User> listener) throws JSONException {
+    if (id == null) {
+      throw new IllegalArgumentException("Security.replaceUser: cannot replace user without an ID");
+    }
+
+    String action = "replaceUser";
+
+    JSONObject data = new JSONObject().put("_id", id).put("body", content);
+
+    if (listener != null) {
+      this.kuzzle.query(buildQueryArgs(action), data, options, new OnQueryDoneListener() {
+        @Override
+        public void onSuccess(JSONObject response) {
+          try {
+            JSONObject result = response.getJSONObject("result");
+            listener.onSuccess(new User(Security.this.kuzzle, result.getString("_id"), result.getJSONObject("_source")));
+          }
+          catch (JSONException e) {
+            throw new RuntimeException(e);
+          }
+        }
+
+        @Override
+        public void onError(JSONObject error) {
+          listener.onError(error);
+        }
+      });
+    }
+    else {
+      this.kuzzle.query(buildQueryArgs(action), data, options);
+    }
+  }
+
+  /**
+   * Replaces an existing user in Kuzzle.
+   *
+   * @param id      - ID of the user to create
+   * @param content - Should contain a 'profile' attribute with the profile ID
+   * @param options - Optional arguments
+   * @throws JSONException the json exception
+   */
+  public void replaceUser(@NonNull final String id, @NonNull final JSONObject content, final Options options) throws JSONException {
+    replaceUser(id, content, options, null);
+  }
+
+  /**
+   * Replaces an existing user in Kuzzle.
+   *
+   * @param id       - ID of the user to create
+   * @param content  - Should contain a 'profile' attribute with the profile ID
+   * @param listener - Callback listener
+   * @throws JSONException the json exception
+   */
+  public void replaceUser(@NonNull final String id, @NonNull final JSONObject content, final ResponseListener<User> listener) throws JSONException {
+    replaceUser(id, content, null, listener);
+  }
+
+  /**
+   * Replaces an existing user in Kuzzle.
+   *
+   * @param id      - ID of the user to create
+   * @param content - Should contain a 'profile' attribute with the profile ID
+   * @throws JSONException the json exception
+   */
+  public void replaceUser(@NonNull final String id, @NonNull final JSONObject content) throws JSONException {
+    replaceUser(id, content, null, null);
+  }
+
+  /**
    * Executes a search on user according to a filter
    * /!\ There is a small delay between user creation and their existence in our persistent search layer,
    * usually a couple of seconds.

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/replaceUserTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/replaceUserTest.java
@@ -1,0 +1,109 @@
+package io.kuzzle.test.security.KuzzleSecurity;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import io.kuzzle.sdk.core.Kuzzle;
+import io.kuzzle.sdk.core.Options;
+import io.kuzzle.sdk.listeners.ResponseListener;
+import io.kuzzle.sdk.listeners.OnQueryDoneListener;
+import io.kuzzle.sdk.security.Security;
+import io.kuzzle.sdk.security.User;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class replaceUserTest {
+    private Kuzzle kuzzle;
+    private Security kuzzleSecurity;
+    private ResponseListener listener;
+    private JSONObject content;
+
+    @Before
+    public void setUp() throws JSONException {
+        kuzzle = mock(Kuzzle.class);
+        kuzzleSecurity = new Security(kuzzle);
+        listener = mock(ResponseListener.class);
+        content = new JSONObject()
+            .put("foo", "bar");
+    }
+
+    @Test
+    public void testReplaceUserNoListener() throws JSONException {
+        kuzzleSecurity.replaceUser("foo", content, new Options());
+        ArgumentCaptor argument = ArgumentCaptor.forClass(Kuzzle.QueryArgs.class);
+        verify(kuzzle, times(1)).query((Kuzzle.QueryArgs) argument.capture(), any(JSONObject.class), any(Options.class));
+        assertEquals(((Kuzzle.QueryArgs) argument.getValue()).controller, "security");
+        assertEquals(((Kuzzle.QueryArgs) argument.getValue()).action, "replaceUser");
+    }
+
+    @Test
+    public void testReplaceUserValidResponse() throws JSONException {
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+            JSONObject response = new JSONObject(
+                "{" +
+                    "\"result\": {" +
+                    "\"_id\": \"foo\"," +
+                    "\"_source\": {}" +
+                    "}" +
+                "}");
+
+                ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(response);
+                ((OnQueryDoneListener) invocation.getArguments()[3]).onError(new JSONObject().put("error", "stub"));
+                return null;
+            }
+        }).when(kuzzle).query(any(Kuzzle.QueryArgs.class), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));
+
+        kuzzleSecurity.replaceUser("foo", content, new ResponseListener<User>() {
+            @Override
+            public void onSuccess(User response) {
+                assertEquals(response.getId(), "foo");
+            }
+
+            @Override
+            public void onError(JSONObject error) {
+                try {
+                    assertEquals(error.getString("error"), "stub");
+                } catch (JSONException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+
+        ArgumentCaptor argument = ArgumentCaptor.forClass(Kuzzle.QueryArgs.class);
+        verify(kuzzle, times(1)).query((Kuzzle.QueryArgs) argument.capture(), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));
+        assertEquals(((Kuzzle.QueryArgs) argument.getValue()).controller, "security");
+        assertEquals(((Kuzzle.QueryArgs) argument.getValue()).action, "replaceUser");
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testReplaceUserBadResponse() throws JSONException {
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+            JSONObject response = new JSONObject();
+
+            ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(response);
+            return null;
+            }
+        }).when(kuzzle).query(any(Kuzzle.QueryArgs.class), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));
+
+        kuzzleSecurity.replaceUser("foo", content, new Options(), listener);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testReplaceUserNoID() throws JSONException {
+        kuzzleSecurity.replaceUser(null, content);
+    }
+}


### PR DESCRIPTION
The new Security:replaceUser route has been added on JS/PHP side, this PR adds it on Android SDK as well.

Already documented in the following PR: https://github.com/kuzzleio/documentation/pull/264/files#diff-28f22657e9045419d382af6dbb7eff6b

fix https://github.com/kuzzleio/kuzzle-sdk/issues/21

# Introduces
- Security:replaceUser support