### PR TITLE
Replace JSONArray with native Arrays for arguments and returned values

### DIFF
--- a/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
+++ b/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
@@ -606,7 +606,7 @@ public class Kuzzle {
    *
    * @param listener the listener
    */
-  public void getAllStatistics(@NonNull final ResponseListener<JSONArray> listener) {
+  public void getAllStatistics(@NonNull final ResponseListener<JSONObject[]> listener) {
     this.getAllStatistics(null, listener);
   }
 
@@ -617,7 +617,7 @@ public class Kuzzle {
    * @param options  the options
    * @param listener the listener
    */
-  public void getAllStatistics(final Options options, @NonNull final ResponseListener<JSONArray> listener) {
+  public void getAllStatistics(final Options options, @NonNull final ResponseListener<JSONObject[]> listener) {
     if (listener == null) {
       throw new IllegalArgumentException("Kuzzle.getAllStatistics: listener required");
     }
@@ -631,7 +631,14 @@ public class Kuzzle {
         @Override
         public void onSuccess(JSONObject object) {
           try {
-            listener.onSuccess(object.getJSONObject("result").getJSONArray("hits"));
+            JSONArray hits = object.getJSONObject("result").getJSONArray("hits");
+            JSONObject[] frames = new JSONObject[hits.length()];
+
+            for(int i = 0; i < hits.length(); i++) {
+              frames[i] = hits.getJSONObject(i);
+            }
+
+            listener.onSuccess(frames);
           } catch (JSONException e) {
             throw new RuntimeException(e);
           }
@@ -794,7 +801,7 @@ public class Kuzzle {
    *
    * @param listener the listener
    */
-  public void listCollections(@NonNull final ResponseListener<JSONObject> listener) {
+  public void listCollections(@NonNull final ResponseListener<JSONObject[]> listener) {
     this.listCollections(null, null, listener);
   }
 
@@ -804,7 +811,7 @@ public class Kuzzle {
    * @param index    the index
    * @param listener the listener
    */
-  public void listCollections(String index, @NonNull final ResponseListener<JSONObject> listener) {
+  public void listCollections(String index, @NonNull final ResponseListener<JSONObject[]> listener) {
     this.listCollections(index, null, listener);
   }
 
@@ -814,7 +821,7 @@ public class Kuzzle {
    * @param options  the options
    * @param listener the listener
    */
-  public void listCollections(Options options, @NonNull final ResponseListener<JSONObject> listener) {
+  public void listCollections(Options options, @NonNull final ResponseListener<JSONObject[]> listener) {
     this.listCollections(null, options, listener);
   }
 
@@ -825,7 +832,7 @@ public class Kuzzle {
    * @param options  the options
    * @param listener the listener
    */
-  public void listCollections(String index, Options options, @NonNull final ResponseListener<JSONObject> listener) {
+  public void listCollections(String index, Options options, @NonNull final ResponseListener<JSONObject[]> listener) {
     if (index == null) {
       if (this.defaultIndex == null) {
         throw new IllegalArgumentException("Kuzzle.listCollections: index required");
@@ -851,7 +858,14 @@ public class Kuzzle {
         @Override
         public void onSuccess(JSONObject collections) {
           try {
-            listener.onSuccess(collections.getJSONObject("result").getJSONObject("collections"));
+            JSONArray result = collections.getJSONObject("result").getJSONArray("collections");
+            JSONObject[] cols = new JSONObject[result.length()];
+
+            for (int i = 0; i < result.length(); i++) {
+              cols[i] = result.getJSONObject(i);
+            }
+
+            listener.onSuccess(cols);
           } catch (JSONException e) {
             throw new RuntimeException(e);
           }
@@ -2632,7 +2646,7 @@ public class Kuzzle {
    * @param listener
    * @return the Security instance
    */
-  public Kuzzle getMyRights(@NonNull final ResponseListener<JSONArray> listener) {
+  public Kuzzle getMyRights(@NonNull final ResponseListener<JSONObject[]> listener) {
     return getMyRights(null, listener);
   }
 
@@ -2643,7 +2657,7 @@ public class Kuzzle {
    * @param listener
    * @return the Security instance
    */
-  public Kuzzle getMyRights(final Options options, @NonNull final ResponseListener<JSONArray> listener) {
+  public Kuzzle getMyRights(final Options options, @NonNull final ResponseListener<JSONObject[]> listener) {
     if (listener == null) {
       throw new IllegalArgumentException("Security.getMyRights: listener is mandatory.");
     }
@@ -2652,7 +2666,14 @@ public class Kuzzle {
         @Override
         public void onSuccess(JSONObject response) {
           try {
-            listener.onSuccess(response.getJSONObject("result").getJSONArray("hits"));
+            JSONArray hits = response.getJSONObject("result").getJSONArray("hits");
+            JSONObject[] rights = new JSONObject[hits.length()];
+
+            for (int i = 0; i < hits.length(); i++) {
+              rights[i] = hits.getJSONObject(i);
+            }
+
+            listener.onSuccess(rights);
           } catch (JSONException e) {
             throw new RuntimeException(e);
           }

--- a/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
+++ b/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
@@ -659,7 +659,7 @@ public class Kuzzle {
    *
    * @param listener the listener
    */
-  public void getStatistics(@NonNull final ResponseListener<JSONObject> listener) {
+  public void getStatistics(@NonNull final ResponseListener<JSONObject[]> listener) {
     this.getStatistics(null, listener);
   }
 
@@ -670,13 +670,14 @@ public class Kuzzle {
    * @param options  the options
    * @param listener the listener
    */
-  public void getStatistics(final Options options, @NonNull final ResponseListener<JSONObject> listener) {
+  public void getStatistics(final Options options, @NonNull final ResponseListener<JSONObject[]> listener) {
     if (listener == null) {
       throw new IllegalArgumentException("Kuzzle.getStatistics: listener required");
     }
     this.isValid();
     JSONObject body = new JSONObject();
     JSONObject data = new JSONObject();
+
     try {
       body.put("body", data);
       QueryArgs args = new QueryArgs();
@@ -686,7 +687,7 @@ public class Kuzzle {
         @Override
         public void onSuccess(JSONObject response) {
           try {
-            listener.onSuccess(response.getJSONObject("result"));
+            listener.onSuccess(new JSONObject[]{response.getJSONObject("result")});
           } catch (JSONException e) {
             throw new RuntimeException(e);
           }
@@ -708,7 +709,7 @@ public class Kuzzle {
    * @param timestamp the timestamp
    * @param listener  the listener
    */
-  public void getStatistics(long timestamp, @NonNull final ResponseListener<JSONArray> listener) {
+  public void getStatistics(long timestamp, @NonNull final ResponseListener<JSONObject[]> listener) {
     this.getStatistics(timestamp, null, listener);
   }
 
@@ -719,7 +720,7 @@ public class Kuzzle {
    * @param options   the options
    * @param listener  the listener
    */
-  public void getStatistics(long timestamp, final Options options, @NonNull final ResponseListener<JSONArray> listener) {
+  public void getStatistics(long timestamp, final Options options, @NonNull final ResponseListener<JSONObject[]> listener) {
     if (listener == null) {
       throw new IllegalArgumentException("Kuzzle.getStatistics: listener required");
     }
@@ -727,6 +728,7 @@ public class Kuzzle {
     this.isValid();
     JSONObject body = new JSONObject();
     JSONObject data = new JSONObject();
+
     try {
       data.put("since", timestamp);
       body.put("body", data);
@@ -737,7 +739,14 @@ public class Kuzzle {
         @Override
         public void onSuccess(JSONObject response) {
           try {
-            listener.onSuccess(response.getJSONObject("result").getJSONArray("hits"));
+            JSONArray hits = response.getJSONObject("result").getJSONArray("hits");
+            JSONObject[] stats = new JSONObject[hits.length()];
+
+            for (int i = 0; i < hits.length(); i++) {
+              stats[i] = hits.getJSONObject(i);
+            }
+
+            listener.onSuccess(stats);
           } catch (JSONException e) {
             throw new RuntimeException(e);
           }

--- a/src/main/java/io/kuzzle/sdk/core/Options.java
+++ b/src/main/java/io/kuzzle/sdk/core/Options.java
@@ -56,12 +56,12 @@ public class Options {
   private boolean alpha = false;
   private String by = null;
   private String direction = null;
-  private JSONArray get = null;
-  private JSONArray limit = null;
+  private String[] get = null;
+  private Integer[] limit = null;
   private boolean ch = false;
   private boolean incr = false;
   private String aggregate = null;
-  private JSONArray weights = null;
+  private Integer[] weights = null;
 
   // Used for getting collections
   private CollectionType collectionType = CollectionType.ALL;
@@ -651,20 +651,20 @@ public class Options {
     return this;
   }
 
-  public JSONArray getGet() {
+  public String[] getGet() {
     return get;
   }
 
-  public Options setGet(JSONArray get) {
+  public Options setGet(String[] get) {
     this.get = get;
     return this;
   }
 
-  public JSONArray getLimit() {
+  public Integer[] getLimit() {
     return limit;
   }
 
-  public Options setLimit(JSONArray limit) {
+  public Options setLimit(Integer[] limit) {
     this.limit = limit;
     return this;
   }
@@ -696,11 +696,11 @@ public class Options {
     return this;
   }
 
-  public JSONArray getWeights() {
+  public Integer[] getWeights() {
     return weights;
   }
 
-  public Options setWeights(JSONArray weights) {
+  public Options setWeights(Integer[] weights) {
     this.weights = weights;
     return this;
   }

--- a/src/main/java/io/kuzzle/sdk/security/Security.java
+++ b/src/main/java/io/kuzzle/sdk/security/Security.java
@@ -839,33 +839,22 @@ public class Security {
   }
 
   /**
-   * Returns the next profiles result set with scroll query.
-   *
-   * @param scroll   - Scroll object
-   * @param listener - Callback listener
-   * @throws JSONException the json exception
-   */
-  public void scrollProfiles(Scroll scroll, final ResponseListener<SecurityDocumentList> listener) throws JSONException {
-    this.scrollProfiles(scroll, new Options(), listener);
-  }
-
-  /**
    * Update profile.
    *
    * @param id       the id
-   * @param content  the content
+   * @param policies  list of policies to apply to this profile
    * @param options  the options
    * @param listener the listener
    * @return Security this object
    * @throws JSONException the json exception
    */
-  public Security updateProfile(@NonNull final String id, final JSONObject content, final Options options, final ResponseListener<Profile> listener) throws JSONException {
+  public Security updateProfile(@NonNull final String id, final JSONObject[] policies, final Options options, final ResponseListener<Profile> listener) throws JSONException {
     if (id == null) {
       throw new IllegalArgumentException("Security.updateProfile: cannot update a profile with ID null");
     }
 
     JSONObject data = new JSONObject().put("_id", id);
-    data.put("body", content);
+    data.put("body", new JSONObject().put("policies", new JSONArray(Arrays.asList(policies))));
 
     if (listener != null) {
       this.kuzzle.query(buildQueryArgs("updateProfile"), data, options, new OnQueryDoneListener() {
@@ -893,41 +882,52 @@ public class Security {
   }
 
   /**
+   * Returns the next profiles result set with scroll query.
+   *
+   * @param scroll   - Scroll object
+   * @param listener - Callback listener
+   * @throws JSONException the json exception
+   */
+  public void scrollProfiles(Scroll scroll, final ResponseListener<SecurityDocumentList> listener) throws JSONException {
+    this.scrollProfiles(scroll, new Options(), listener);
+  }
+
+  /**
    * Update profile.
    *
    * @param id      the id
-   * @param content the content
+   * @param policies  list of policies to apply to this profile
    * @param options the options
    * @return Security this object
    * @throws JSONException the json exception
    */
-  public Security updateProfile(@NonNull final String id, final JSONObject content, final Options options) throws JSONException {
-    return updateProfile(id, content, options, null);
+  public Security updateProfile(@NonNull final String id, final JSONObject[] policies, final Options options) throws JSONException {
+    return updateProfile(id, policies, options, null);
   }
 
   /**
    * Update profile.
    *
    * @param id       the id
-   * @param content  the content
+   * @param policies  list of policies to apply to this profile
    * @param listener the listener
    * @return Security this object
    * @throws JSONException the json exception
    */
-  public Security updateProfile(@NonNull final String id, final JSONObject content, final ResponseListener<Profile> listener) throws JSONException {
-    return this.updateProfile(id, content, null, listener);
+  public Security updateProfile(@NonNull final String id, final JSONObject[] policies, final ResponseListener<Profile> listener) throws JSONException {
+    return this.updateProfile(id, policies, null, listener);
   }
 
   /**
    * Update profile.
    *
    * @param id      the id
-   * @param content the content
+   * @param policies  list of policies to apply to this profile
    * @return Security this object
    * @throws JSONException the json exception
    */
-  public Security updateProfile(@NonNull final String id, final JSONObject content) throws JSONException {
-    return updateProfile(id, content, null, null);
+  public Security updateProfile(@NonNull final String id, final JSONObject[] policies) throws JSONException {
+    return updateProfile(id, policies, null, null);
   }
 
   /**

--- a/src/main/java/io/kuzzle/sdk/security/Security.java
+++ b/src/main/java/io/kuzzle/sdk/security/Security.java
@@ -7,6 +7,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 
 import io.kuzzle.sdk.core.Kuzzle;
 import io.kuzzle.sdk.core.Options;
@@ -597,19 +598,21 @@ public class Security {
    * Replace the existing profile otherwise
    *
    * @param id       - ID of the new profile
-   * @param content  - Should contain a 'roles' attributes containing the roles referenced by this profile
+   * @param policies  - list of policies attached to the new profile
    * @param options  - Optional arguments
    * @param listener - Callback lisener
    * @throws JSONException the json exception
    */
-  public void createProfile(@NonNull final String id, @NonNull final JSONArray content, final Options options, final ResponseListener<Profile> listener) throws JSONException {
+  public void createProfile(@NonNull final String id, @NonNull final JSONObject[] policies, final Options options, final ResponseListener<Profile> listener) throws JSONException {
     String action = "createProfile";
 
-    if (id == null || content == null) {
-      throw new IllegalArgumentException("Security.createProfile: cannot create a profile with null ID or roles");
+    if (id == null || policies == null) {
+      throw new IllegalArgumentException("Security.createProfile: cannot create a profile with null ID or policies");
     }
 
-    JSONObject data = new JSONObject().put("_id", id).put("body", new JSONObject().put("roles", content));
+    JSONObject data = new JSONObject()
+      .put("_id", id)
+      .put("body", new JSONObject().put("policies", new JSONArray(Arrays.asList(policies))));
 
     if (options != null && options.isReplaceIfExist()) {
       action = "createOrReplaceProfile";
@@ -647,12 +650,12 @@ public class Security {
    * Replace the existing profile otherwise
    *
    * @param id      - ID of the new profile
-   * @param content - Should contain a 'roles' attributes containing the roles referenced by this profile
+   * @param policies  - list of policies attached to the new profile
    * @param options - Optional arguments
    * @throws JSONException the json exception
    */
-  public void createProfile(@NonNull final String id, @NonNull final JSONArray content, final Options options) throws JSONException {
-    createProfile(id, content, options, null);
+  public void createProfile(@NonNull final String id, @NonNull final JSONObject[] policies, final Options options) throws JSONException {
+    createProfile(id, policies, options, null);
   }
 
   /**
@@ -663,12 +666,12 @@ public class Security {
    * Replace the existing profile otherwise
    *
    * @param id       - ID of the new profile
-   * @param content  - Should contain a 'roles' attributes containing the roles referenced by this profile
+   * @param policies  - list of policies attached to the new profile
    * @param listener - Callback lisener
    * @throws JSONException the json exception
    */
-  public void createProfile(@NonNull final String id, @NonNull final JSONArray content, final ResponseListener<Profile> listener) throws JSONException {
-    createProfile(id, content, null, listener);
+  public void createProfile(@NonNull final String id, @NonNull final JSONObject[] policies, final ResponseListener<Profile> listener) throws JSONException {
+    createProfile(id, policies, null, listener);
   }
 
   /**
@@ -679,11 +682,11 @@ public class Security {
    * Replace the existing profile otherwise
    *
    * @param id      - ID of the new profile
-   * @param content - Should contain a 'roles' attributes containing the roles referenced by this profile
+   * @param policies  - list of policies attached to the new profile
    * @throws JSONException the json exception
    */
-  public void createProfile(@NonNull final String id, @NonNull final JSONArray content) throws JSONException {
-    createProfile(id, content, null, null);
+  public void createProfile(@NonNull final String id, @NonNull final JSONObject[] policies) throws JSONException {
+    createProfile(id, policies, null, null);
   }
 
   /**

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/getAllStatisticsTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/getAllStatisticsTest.java
@@ -1,6 +1,5 @@
 package io.kuzzle.test.core.Kuzzle;
 
-import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -14,7 +13,6 @@ import java.util.Iterator;
 
 import io.kuzzle.sdk.core.Options;
 import io.kuzzle.sdk.enums.Mode;
-import io.kuzzle.sdk.enums.State;
 import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.States;
@@ -127,14 +125,14 @@ public class getAllStatisticsTest {
         return null;
       }
     }).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));
-    kuzzle.getAllStatistics(new ResponseListener<JSONArray>() {
+    kuzzle.getAllStatistics(new ResponseListener<JSONObject[]>() {
       @Override
-      public void onSuccess(JSONArray result) {
+      public void onSuccess(JSONObject[] result) {
         try {
-          for (int i = 0; i < result.length(); i++) {
-            for (Iterator ite = result.getJSONObject(i).keys(); ite.hasNext(); ) {
+          for (int i = 0; i < result.length; i++) {
+            for (Iterator ite = result[i].keys(); ite.hasNext(); ) {
               String key = (String) ite.next();
-              assertEquals(result.getJSONObject(i).get(key), response.getJSONArray("hits").getJSONObject(i).get(key));
+              assertEquals(result[i].get(key), response.getJSONArray("hits").getJSONObject(i).get(key));
             }
           }
         } catch (JSONException e) {
@@ -166,9 +164,9 @@ public class getAllStatisticsTest {
         return null;
       }
     }).when(kuzzle).query(eq(QueryArgsHelper.makeQueryArgs("server", "getAllStats")), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));
-    kuzzle.getAllStatistics(new ResponseListener<JSONArray>() {
+    kuzzle.getAllStatistics(new ResponseListener<JSONObject[]>() {
       @Override
-      public void onSuccess(JSONArray object) {
+      public void onSuccess(JSONObject[] object) {
       }
 
       @Override

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/getStatisticsTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/getStatisticsTest.java
@@ -112,7 +112,7 @@ public class getStatisticsTest {
       "          websocket: 13\n" +
       "        },\n" +
       "        \"timestamp\": \"2016-01-13T13:46:19.917Z\"\n" +
-      "      },\n"  +
+      "      }\n"  +
       "    ]\n" +
       "  }" +
       "}");

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/getStatisticsTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/getStatisticsTest.java
@@ -112,8 +112,7 @@ public class getStatisticsTest {
       "          websocket: 13\n" +
       "        },\n" +
       "        \"timestamp\": \"2016-01-13T13:46:19.917Z\"\n" +
-      "      },\n" +
-      "      ...\n" +
+      "      },\n"  +
       "    ]\n" +
       "  }" +
       "}");

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/listCollectionsTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/listCollectionsTest.java
@@ -103,7 +103,7 @@ public class listCollectionsTest {
     doAnswer(new Answer() {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {
-        ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(new JSONObject().put("result", new JSONObject().put("collections", mock(JSONObject.class))));
+        ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(new JSONObject().put("result", new JSONObject().put("collections", mock(JSONArray.class))));
         ((OnQueryDoneListener) invocation.getArguments()[3]).onError(mock(JSONObject.class));
         return null;
       }

--- a/src/test/java/io/kuzzle/test/security/KuzzleProfileTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleProfileTest.java
@@ -1,6 +1,5 @@
 package io.kuzzle.test.security;
 
-import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -17,7 +16,6 @@ import io.kuzzle.sdk.security.Profile;
 import io.kuzzle.sdk.security.Security;
 
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -31,13 +29,11 @@ import static org.mockito.Mockito.verify;
 public class KuzzleProfileTest {
   private Kuzzle kuzzle;
   private Profile stubProfile;
-  private ResponseListener listener;
 
   @Before
   public void setUp() throws JSONException {
     kuzzle = mock(Kuzzle.class);
     kuzzle.security = new Security(kuzzle);
-    listener = mock(ResponseListener.class);
     stubProfile = new Profile(kuzzle, "foo", null);
   }
 
@@ -45,7 +41,7 @@ public class KuzzleProfileTest {
   public void testConstructorNoContent() throws JSONException {
     Profile profile = new Profile(kuzzle, "foo", null);
     assertEquals(profile.id, "foo");
-    assertEquals(profile.getPolicies().length(), 0);
+    assertEquals(profile.getPolicies().length, 0);
     assertThat(profile.content, instanceOf(JSONObject.class));
     assertEquals(profile.content.length(), 0);
   }
@@ -59,8 +55,8 @@ public class KuzzleProfileTest {
     );
     Profile profile = new Profile(kuzzle, "foo", content);
     assertEquals(profile.id, "foo");
-    assertEquals(profile.getPolicies().length(), 3);
-    assertEquals(profile.getPolicies().getJSONObject(2).getString("roleId"), "baz");
+    assertEquals(profile.getPolicies().length, 3);
+    assertEquals(profile.getPolicies()[2].getString("roleId"), "baz");
     assertThat(profile.content, instanceOf(JSONObject.class));
     assertEquals(profile.content.length(), 0);
   }
@@ -78,8 +74,8 @@ public class KuzzleProfileTest {
     );
     Profile profile = new Profile(kuzzle, "foo", content);
     assertEquals(profile.id, "foo");
-    assertEquals(profile.getPolicies().length(), 3);
-    assertEquals(profile.getPolicies().getJSONObject(2).getString("roleId"), "baz");
+    assertEquals(profile.getPolicies().length, 3);
+    assertEquals(profile.getPolicies()[2].getString("roleId"), "baz");
     assertThat(profile.content, instanceOf(JSONObject.class));
     assertEquals(profile.content.length(), 0);
   }
@@ -87,8 +83,8 @@ public class KuzzleProfileTest {
   @Test
   public void testAddPolicyObject() throws JSONException {
     stubProfile.addPolicy(new JSONObject().put("roleId", "some role"));
-    assertEquals(stubProfile.getPolicies().length(), 1);
-    assertTrue(stubProfile.getPolicies().getJSONObject(0).getString("roleId") == "some role");
+    assertEquals(stubProfile.getPolicies().length, 1);
+    assertEquals(stubProfile.getPolicies()[0].getString("roleId"), "some role");
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -100,8 +96,8 @@ public class KuzzleProfileTest {
   @Test
   public void testAddPolicyID() throws JSONException {
     stubProfile.addPolicy("another role");
-    assertEquals(stubProfile.getPolicies().length(), 1);
-    assertTrue(stubProfile.getPolicies().getJSONObject(0).getString("roleId") == "another role");
+    assertEquals(stubProfile.getPolicies().length, 1);
+    assertEquals(stubProfile.getPolicies()[0].getString("roleId"), "another role");
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -157,14 +153,18 @@ public class KuzzleProfileTest {
 
   @Test
   public void testSetPoliciesObjectList() throws JSONException {
-    JSONArray policies = new JSONArray("[{\"roleId\": \"bar\"},{\"roleId\": \"baz\"},{\"roleId\": \"qux\"}]");
+    JSONObject[] policies = new JSONObject[]{
+      new JSONObject().put("roleId", "bar"),
+      new JSONObject().put("roleId", "baz"),
+      new JSONObject().put("roleId", "qux")
+    };
 
     stubProfile.addPolicy("foo");
     stubProfile.setPolicies(policies);
-    assertEquals(stubProfile.getPolicies().length(), 3);
-    assertEquals(stubProfile.getPolicies().getJSONObject(0).getString("roleId"), "bar");
-    assertEquals(stubProfile.getPolicies().getJSONObject(1).getString("roleId"), "baz");
-    assertEquals(stubProfile.getPolicies().getJSONObject(2).getString("roleId"), "qux");
+    assertEquals(stubProfile.getPolicies().length, 3);
+    assertEquals(stubProfile.getPolicies()[0].getString("roleId"), "bar");
+    assertEquals(stubProfile.getPolicies()[1].getString("roleId"), "baz");
+    assertEquals(stubProfile.getPolicies()[2].getString("roleId"), "qux");
   }
 
   @Test
@@ -172,19 +172,24 @@ public class KuzzleProfileTest {
     String[] policies = {"bar", "baz", "qux"};
 
     stubProfile.addPolicy("foo");
+    assertEquals(stubProfile.getPolicies().length, 1);
+
     stubProfile.setPolicies(policies);
-    assertEquals(stubProfile.getPolicies().length(), 4);
-    assertEquals(stubProfile.getPolicies().getJSONObject(0).getString("roleId"), "foo");
-    assertEquals(stubProfile.getPolicies().getJSONObject(1).getString("roleId"), "bar");
-    assertEquals(stubProfile.getPolicies().getJSONObject(2).getString("roleId"), "baz");
-    assertEquals(stubProfile.getPolicies().getJSONObject(3).getString("roleId"), "qux");
+    assertEquals(stubProfile.getPolicies().length, 3);
+    assertEquals(stubProfile.getPolicies()[0].getString("roleId"), "bar");
+    assertEquals(stubProfile.getPolicies()[1].getString("roleId"), "baz");
+    assertEquals(stubProfile.getPolicies()[2].getString("roleId"), "qux");
+
+    stubProfile.addPolicy("foo");
+    assertEquals(stubProfile.getPolicies().length, 4);
+    assertEquals(stubProfile.getPolicies()[3].getString("roleId"), "foo");
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testSetBadPolicies() throws JSONException {
-    stubProfile.setPolicies(new JSONArray("[{\"bad\":\"policy\"}]"));
+    stubProfile.setPolicies(new JSONObject[]{new JSONObject().put("bad", "policy")});
 
-    doThrow(IllegalArgumentException.class).when(stubProfile).setPolicies(any(JSONArray.class));
+    doThrow(IllegalArgumentException.class).when(stubProfile).setPolicies(any(JSONObject[].class));
   }
 
   @Test

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/createProfileTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/createProfileTest.java
@@ -37,7 +37,7 @@ public class createProfileTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testCreateProfileNoID() throws JSONException {
-    kuzzleSecurity.createProfile(null, new JSONArray());
+    kuzzleSecurity.createProfile(null, new JSONObject[0]);
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -47,7 +47,7 @@ public class createProfileTest {
 
   @Test
   public void testCreateProfileNoListener() throws JSONException {
-    kuzzleSecurity.createProfile("foo", new JSONArray(), new Options());
+    kuzzleSecurity.createProfile("foo", new JSONObject[0], new Options());
     ArgumentCaptor argument = ArgumentCaptor.forClass(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class);
     verify(kuzzle, times(1)).query((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.capture(), any(JSONObject.class), any(Options.class));
     assertEquals(((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.getValue()).controller, "security");
@@ -58,7 +58,7 @@ public class createProfileTest {
   public void testCreateProfileReplaceIfExists() throws JSONException {
     Options options = new Options().setReplaceIfExist(true);
 
-    kuzzleSecurity.createProfile("foo", new JSONArray(), options);
+    kuzzleSecurity.createProfile("foo", new JSONObject[0], options);
     ArgumentCaptor argument = ArgumentCaptor.forClass(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class);
     verify(kuzzle, times(1)).query((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.capture(), any(JSONObject.class), any(Options.class));
     assertEquals(((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.getValue()).controller, "security");
@@ -86,7 +86,7 @@ public class createProfileTest {
       }
     }).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));
 
-    kuzzleSecurity.createProfile("foobar", new JSONArray(), new ResponseListener<Profile>() {
+    kuzzleSecurity.createProfile("foobar", new JSONObject[0], new ResponseListener<Profile>() {
       @Override
       public void onSuccess(Profile response) {
         assertEquals(response.id, "foobar");
@@ -120,6 +120,6 @@ public class createProfileTest {
       }
     }).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));
 
-    kuzzleSecurity.createProfile("foobar", new JSONArray(), listener);
+    kuzzleSecurity.createProfile("foobar", new JSONObject[0], listener);
   }
 }

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/isActionAllowedTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/isActionAllowedTest.java
@@ -1,6 +1,5 @@
 package io.kuzzle.test.security.KuzzleSecurity;
 
-import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -11,15 +10,14 @@ import io.kuzzle.sdk.enums.Policies;
 import io.kuzzle.sdk.security.Security;
 
 import static junit.framework.Assert.assertEquals;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
 public class isActionAllowedTest {
-
-  private Kuzzle kuzzle;
   private Security kuzzleSecurity;
-  private JSONArray policies;
+  private JSONObject[] policies;
 
   private JSONObject addProperties(final String ctrl, final String action, final String idx, final String collection, final String value) throws JSONException {
     return new JSONObject()
@@ -32,21 +30,22 @@ public class isActionAllowedTest {
 
   @Before
   public void setUp() throws JSONException {
-    kuzzle = mock(Kuzzle.class);
+    Kuzzle kuzzle = mock(Kuzzle.class);
     kuzzleSecurity = new Security(kuzzle);
-    policies = new JSONArray()
-        .put(addProperties("document", "get", "*", "*", Policies.allowed.toString()))
-        .put(addProperties("document", "count", "*", "*", Policies.allowed.toString()))
-        .put(addProperties("document", "search", "*", "*", Policies.allowed.toString()))
-        .put(addProperties("document", "*", "index1", "collection1", Policies.allowed.toString()))
-        .put(addProperties("document", "*", "index1", "collection2", Policies.allowed.toString()))
-        .put(addProperties("document", "update", "*", "*", Policies.allowed.toString()))
-        .put(addProperties("document", "create", "*", "*", Policies.allowed.toString()))
-        .put(addProperties("document", "createOrReplace", "*", "*", Policies.allowed.toString()))
-        .put(addProperties("document", "delete", "*", "*", Policies.conditional.toString()))
-        .put(addProperties("realtime", "publish", "index2", "*", Policies.allowed.toString()))
-        .put(addProperties("security", "searchUsers", "*", "*", Policies.allowed.toString()))
-        .put(addProperties("security", "updateUser", "*", "*", Policies.conditional.toString()));
+    policies = new JSONObject[]{
+      addProperties("document", "get", "*", "*", Policies.allowed.toString()),
+      addProperties("document", "count", "*", "*", Policies.allowed.toString()),
+      addProperties("document", "search", "*", "*", Policies.allowed.toString()),
+      addProperties("document", "*", "index1", "collection1", Policies.allowed.toString()),
+      addProperties("document", "*", "index1", "collection2", Policies.allowed.toString()),
+      addProperties("document", "update", "*", "*", Policies.allowed.toString()),
+      addProperties("document", "create", "*", "*", Policies.allowed.toString()),
+      addProperties("document", "createOrReplace", "*", "*", Policies.allowed.toString()),
+      addProperties("document", "delete", "*", "*", Policies.conditional.toString()),
+      addProperties("realtime", "publish", "index2", "*", Policies.allowed.toString()),
+      addProperties("security", "searchUsers", "*", "*", Policies.allowed.toString()),
+      addProperties("security", "updateUser", "*", "*", Policies.conditional.toString())
+    };
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -115,9 +114,9 @@ public class isActionAllowedTest {
   }
 
   @Test(expected = RuntimeException.class)
-  public void testJsonException() {
-    policies = spy(policies);
-    doThrow(JSONException.class).when(policies).length();
+  public void testJsonException() throws JSONException {
+    JSONObject spy = spy(policies[0]);
+    doThrow(JSONException.class).when(spy.getString(any(String.class)));
     kuzzleSecurity.isActionAllowed(policies, "document", "delete", "index1", "collection1");
   }
 

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/updateProfileTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/updateProfileTest.java
@@ -26,20 +26,19 @@ public class updateProfileTest {
   private Kuzzle kuzzle;
   private Security kuzzleSecurity;
   private ResponseListener listener;
-  private JSONObject  content;
+  private JSONObject[] policies;
 
   @Before
   public void setUp() throws JSONException {
     kuzzle = mock(Kuzzle.class);
     kuzzleSecurity = new Security(kuzzle);
     listener = mock(ResponseListener.class);
-    content = new JSONObject()
-        .put("foo", "bar");
+    policies = new JSONObject[]{new JSONObject().put("foo", "bar")};
   }
 
   @Test
   public void testUpdateProfileNoListener() throws JSONException {
-    kuzzleSecurity.updateProfile("foo", content, new Options());
+    kuzzleSecurity.updateProfile("foo", policies, new Options());
     ArgumentCaptor argument = ArgumentCaptor.forClass(Kuzzle.QueryArgs.class);
     verify(kuzzle, times(1)).query((Kuzzle.QueryArgs) argument.capture(), any(JSONObject.class), any(Options.class));
     assertEquals(((Kuzzle.QueryArgs) argument.getValue()).controller, "security");
@@ -65,7 +64,7 @@ public class updateProfileTest {
       }
     }).when(kuzzle).query(any(Kuzzle.QueryArgs.class), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));
 
-    kuzzleSecurity.updateProfile("foobar", content, new ResponseListener<Profile>() {
+    kuzzleSecurity.updateProfile("foobar", policies, new ResponseListener<Profile>() {
       @Override
       public void onSuccess(Profile response) {
         assertEquals(response.getId(), "foobar");
@@ -99,11 +98,11 @@ public class updateProfileTest {
       }
     }).when(kuzzle).query(any(Kuzzle.QueryArgs.class), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));
 
-    kuzzleSecurity.updateProfile("foobar", content, new Options(), listener);
+    kuzzleSecurity.updateProfile("foobar", policies, new Options(), listener);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testUpdateProfileNoID() throws JSONException {
-    kuzzleSecurity.updateProfile(null, content);
+    kuzzleSecurity.updateProfile(null, policies);
   }
 }


### PR DESCRIPTION
# Description

It has been decided that it makes little sense to force Android SDK clients to use `JSONArray` to pass a collection of objects, or to receive one as a return value/callback resolution value.
Moreover, using `JSONArray` is inconsistent with the documentation and the way other SDKs are implemented.

So all `JSONArray` usages in arguments or in return values have been replaced by native arrays.

# Other breaking change

* `Security.createProfile` and `Security.updateProfile` have had their input format changed: these methods now both accept an array of policies, instead of a complex and counterintuitive JSONObject instance

* The `MemoryStorage.*scan` methods (hscan/scan/sscan/zscan) have had their format changed, from:

```json
[
  42,
  [
    "value1",
    "value2",
    "..."
  ]
]
```

To:

```json
{
  "cursor": 42,
  "values": [
    "value1",
    "value2,
    "..."
  ]
}
```

# Documentation pull request

https://github.com/kuzzleio/documentation/pull/281
