### PR TITLE
Add specification CRUDL routes

### DIFF
--- a/src/main/java/io/kuzzle/sdk/core/Collection.java
+++ b/src/main/java/io/kuzzle/sdk/core/Collection.java
@@ -904,7 +904,7 @@ public class Collection {
    * @param listener Response callback
    * @return Collection Kuzzle data collection
    */
-  public Collection deleteSpecifications(final ResponseListener<JSONObject> listener) throws JSONException {
+  public Collection deleteSpecifications(final ResponseListener<Boolean> listener) throws JSONException {
     return this.deleteSpecifications(new Options(), listener);
   }
 
@@ -915,7 +915,7 @@ public class Collection {
    * @param listener Response callback
    * @return Collection Kuzzle data collection
    */
-  public Collection deleteSpecifications(final Options options, final ResponseListener<JSONObject> listener) throws JSONException {
+  public Collection deleteSpecifications(final Options options, final ResponseListener<Boolean> listener) throws JSONException {
     JSONObject data = new JSONObject();
 
     try {
@@ -925,7 +925,7 @@ public class Collection {
         public void onSuccess(JSONObject response) {
           if (listener != null) {
             try {
-              listener.onSuccess(response.getJSONObject("result"));
+              listener.onSuccess(response.getBoolean("result"));
             } catch (JSONException e) {
               throw new RuntimeException(e);
             }

--- a/src/main/java/io/kuzzle/sdk/core/Collection.java
+++ b/src/main/java/io/kuzzle/sdk/core/Collection.java
@@ -904,7 +904,7 @@ public class Collection {
    * @param listener Response callback
    * @return Collection Kuzzle data collection
    */
-  public Collection deleteSpecifications(final ResponseListener<Boolean> listener) throws JSONException {
+  public Collection deleteSpecifications(final ResponseListener<JSONObject> listener) throws JSONException {
     return this.deleteSpecifications(new Options(), listener);
   }
 
@@ -915,7 +915,7 @@ public class Collection {
    * @param listener Response callback
    * @return Collection Kuzzle data collection
    */
-  public Collection deleteSpecifications(final Options options, final ResponseListener<Boolean> listener) throws JSONException {
+  public Collection deleteSpecifications(final Options options, final ResponseListener<JSONObject> listener) throws JSONException {
     JSONObject data = new JSONObject();
 
     try {
@@ -925,7 +925,7 @@ public class Collection {
         public void onSuccess(JSONObject response) {
           if (listener != null) {
             try {
-              listener.onSuccess(response.getBoolean("result"));
+              listener.onSuccess(response.getJSONObject("result"));
             } catch (JSONException e) {
               throw new RuntimeException(e);
             }

--- a/src/main/java/io/kuzzle/sdk/core/Collection.java
+++ b/src/main/java/io/kuzzle/sdk/core/Collection.java
@@ -197,16 +197,145 @@ public class Collection {
             }
 
             response = new SearchResult(
-                    Collection.this,
-                    object.getJSONObject("result").getInt("total"),
-                    docs,
-                    new JSONObject(),
-                    options,
-                    filters,
-                    options.getPrevious()
+              Collection.this,
+              object.getJSONObject("result").getInt("total"),
+              docs,
+              new JSONObject(),
+              options,
+              filters,
+              options.getPrevious()
             );
 
             listener.onSuccess(response);
+          } catch (JSONException e) {
+            throw new RuntimeException(e);
+          }
+        }
+
+        @Override
+        public void onError(JSONObject error) {
+          listener.onError(error);
+        }
+      });
+    } catch (JSONException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Scrolls through specifications using the provided scrollId
+   *
+   * @param scrollId string
+   * @param listener Response callback
+   */
+  public void scrollSpecifications(@NonNull final String scrollId, @NonNull final ResponseListener<JSONObject> listener) {
+    this.scrollSpecifications(scrollId, new Options(), listener);
+  }
+
+  /**
+   * Scrolls through specifications using the provided scrollId
+   *
+   * @param scrollId string
+   * @param options Options Optional parameters
+   * @param listener Response callback
+   */
+  public void scrollSpecifications(@NonNull final String scrollId, final Options options, @NonNull final ResponseListener<JSONObject> listener) {
+    this.kuzzle.isValid();
+
+    JSONObject data = new JSONObject();
+
+    if (scrollId == null) {
+      throw new RuntimeException("Collection.scrollSpecifications: scrollId is required");
+    }
+
+    if (listener == null) {
+      throw new IllegalArgumentException("listener cannot be null");
+    }
+
+    try {
+      data.put("scrollId", scrollId);
+
+      this.kuzzle.addHeaders(data, this.getHeaders());
+
+      this.kuzzle.query(makeQueryArgs("collection", "scrollSpecifications"), data, options, new OnQueryDoneListener() {
+        @Override
+        public void onSuccess(JSONObject response) {
+          try {
+            listener.onSuccess(response.getJSONObject("result"));
+          } catch (JSONException e) {
+            throw new RuntimeException(e);
+          }
+        }
+
+        @Override
+          public void onError(JSONObject error) {
+            listener.onError(error);
+          }
+      });
+    } catch (JSONException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Searches specifications across indexes/collections according to the provided filters
+   *
+   * @param listener Response callback
+   */
+  public void searchSpecifications(@NonNull final ResponseListener<JSONObject> listener) {
+    this.searchSpecifications(null, new Options(), listener);
+  }
+
+  /**
+   * Searches specifications across indexes/collections according to the provided filters
+   *
+   * @param filters JSONObject Optional filters in ElasticSearch Query DSL format
+   * @param listener Response callback
+   */
+  public void searchSpecifications(final JSONObject filters, @NonNull final ResponseListener<JSONObject> listener) {
+    this.searchSpecifications(filters, new Options(), listener);
+  }
+
+  /**
+   * Searches specifications across indexes/collections according to the provided filters
+   *
+   * @param options Options Optional parameters
+   * @param listener Response callback
+   */
+  public void searchSpecifications(final Options options, @NonNull final ResponseListener<JSONObject> listener) {
+    this.searchSpecifications(null, options, listener);
+  }
+
+  /**
+   * Searches specifications across indexes/collections according to the provided filters
+   *
+   * @param filters JSONObject Optional filters in ElasticSearch Query DSL format
+   * @param options Options Optional parameters
+   * @param listener Response callback
+   */
+  public void searchSpecifications(final JSONObject filters, final Options options, @NonNull final ResponseListener<JSONObject> listener) {
+    this.kuzzle.isValid();
+
+    JSONObject data = new JSONObject();
+
+    if (listener == null) {
+      throw new IllegalArgumentException("listener cannot be null");
+    }
+
+    try {
+      if (filters != null) {
+        data.put("body", new JSONObject()
+          .put("query", filters)
+        );
+      }
+
+      this.kuzzle.addHeaders(data, this.getHeaders());
+
+      this.kuzzle.query(makeQueryArgs("collection", "searchSpecifications"), data, options, new OnQueryDoneListener() {
+        @Override
+        public void onSuccess(JSONObject response) {
+          try {
+            listener.onSuccess(response.getJSONObject("result"));
           } catch (JSONException e) {
             throw new RuntimeException(e);
           }
@@ -751,6 +880,73 @@ public class Collection {
   }
 
   /**
+   * Deletes the current specifications of this collection
+   *
+   * @return Collection Kuzzle data collection
+   */
+  public Collection deleteSpecifications() throws JSONException {
+    return this.deleteSpecifications(new Options(), null);
+  }
+
+  /**
+   * Deletes the current specifications of this collection
+   *
+   * @param options Options Optional parameters
+   * @return Collection Kuzzle data collection
+   */
+  public Collection deleteSpecifications(final Options options) throws JSONException {
+    return this.deleteSpecifications(options, null);
+  }
+
+  /**
+   * Deletes the current specifications of this collection
+   *
+   * @param listener Response callback
+   * @return Collection Kuzzle data collection
+   */
+  public Collection deleteSpecifications(final ResponseListener<JSONObject> listener) throws JSONException {
+    return this.deleteSpecifications(new Options(), listener);
+  }
+
+  /**
+   * Deletes the current specifications of this collection
+   *
+   * @param options Options Optional parameters
+   * @param listener Response callback
+   * @return Collection Kuzzle data collection
+   */
+  public Collection deleteSpecifications(final Options options, final ResponseListener<JSONObject> listener) throws JSONException {
+    JSONObject data = new JSONObject();
+
+    try {
+      this.kuzzle.addHeaders(data, this.getHeaders());
+      this.kuzzle.query(makeQueryArgs("collection", "deleteSpecifications"), data, options, new OnQueryDoneListener() {
+        @Override
+        public void onSuccess(JSONObject response) {
+          if (listener != null) {
+            try {
+              listener.onSuccess(response.getJSONObject("result"));
+            } catch (JSONException e) {
+              throw new RuntimeException(e);
+            }
+          }
+        }
+
+        @Override
+        public void onError(JSONObject error) {
+          if (listener != null) {
+            listener.onError(error);
+          }
+        }
+      });
+    } catch (JSONException e) {
+      throw new RuntimeException(e);
+    }
+
+    return this;
+  }
+
+  /**
    * Document factory kuzzle document.
    *
    * @return the kuzzle document
@@ -893,6 +1089,47 @@ public class Collection {
    */
   public void getMapping(@NonNull final ResponseListener<CollectionMapping> listener) {
     this.getMapping(null, listener);
+  }
+
+  /**
+   * Retrieves the current specifications of this collection
+   *
+   * @param listener Response callback
+   */
+  public void getSpecifications(@NonNull final ResponseListener<JSONObject> listener) throws JSONException {
+    this.getSpecifications(new Options(), listener);
+  }
+
+  /**
+   * Retrieves the current specifications of this collection
+   *
+   * @param options Optional parameters
+   * @param listener Response callback
+   */
+  public void getSpecifications(final Options options, @NonNull final ResponseListener<JSONObject> listener) throws JSONException {
+    JSONObject data = new JSONObject()
+      .put("body", new JSONObject());
+
+    try {
+      this.kuzzle.addHeaders(data, this.getHeaders());
+      this.kuzzle.query(makeQueryArgs("collection", "getSpecifications"), data, options, new OnQueryDoneListener() {
+        @Override
+        public void onSuccess(JSONObject response) {
+          try {
+            listener.onSuccess(response.getJSONObject("result"));
+          } catch (JSONException e) {
+            throw new RuntimeException(e);
+          }
+        }
+
+        @Override
+        public void onError(JSONObject error) {
+          listener.onError(error);
+        }
+      });
+    } catch (JSONException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   /**
@@ -1547,6 +1784,57 @@ public class Collection {
   }
 
   /**
+   * Validates the provided specifications
+   *
+   * @param specifications JSONObject Specifications content
+   * @param listener Response callback
+   */
+  public void validateSpecifications(@NonNull JSONObject specifications, @NonNull ResponseListener<Boolean> listener) throws JSONException {
+    this.validateSpecifications(specifications, new Options(), listener);
+  }
+
+  /**
+   * Validates the provided specifications
+   *
+   * @param specifications JSONObject Specifications content
+   * @param options Options Optional parameters
+   * @param listener Response callback
+   */
+  public void validateSpecifications(@NonNull JSONObject specifications, Options options, @NonNull final ResponseListener<Boolean> listener) throws JSONException {
+    if (specifications == null) {
+      throw new IllegalArgumentException("Collection.validateSpecifications: specifications cannot be null");
+    }
+
+    JSONObject data = new JSONObject()
+      .put("body", new JSONObject()
+        .put(this.getIndex(), new JSONObject()
+          .put(this.getCollection(), specifications)
+        )
+      );
+
+    try {
+      this.kuzzle.addHeaders(data, this.getHeaders());
+      this.kuzzle.query(makeQueryArgs("collection", "validateSpecifications"), data, options, new OnQueryDoneListener() {
+        @Override
+        public void onSuccess(JSONObject response) {
+          try {
+            listener.onSuccess(response.getJSONObject("result").getBoolean("valid"));
+          } catch (JSONException e) {
+            throw new RuntimeException(e);
+          }
+        }
+
+        @Override
+        public void onError(JSONObject error) {
+          listener.onError(error);
+        }
+      });
+    } catch (JSONException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
    * Room factory kuzzle room.
    *
    * @return the kuzzle room
@@ -1806,6 +2094,86 @@ public class Collection {
     } catch (JSONException e) {
       throw new RuntimeException(e);
     }
+    return this;
+  }
+
+  /**
+   * Updates the current specifications of this collection
+   *
+   * @param specifications JSONObject Specifications content
+   * @return Collection Kuzzle data collection
+   */
+  public Collection updateSpecifications(@NonNull final JSONObject specifications) throws JSONException {
+    return this.updateSpecifications(specifications, new Options(), null);
+  }
+
+  /**
+   * Updates the current specifications of this collection
+   *
+   * @param specifications JSONObject Specifications content
+   * @param options Options Optional parameters
+   * @return Collection Kuzzle data collection
+   */
+  public Collection updateSpecifications(@NonNull final JSONObject specifications, final Options options) throws JSONException {
+    return this.updateSpecifications(specifications, options, null);
+  }
+
+  /**
+   * Updates the current specifications of this collection
+   *
+   * @param specifications JSONObject Specifications content
+   * @param listener Response callback
+   * @return Collection Kuzzle data collection
+   */
+  public Collection updateSpecifications(@NonNull final JSONObject specifications, final ResponseListener<JSONObject> listener) throws JSONException {
+    return this.updateSpecifications(specifications, new Options(), listener);
+  }
+
+  /**
+   * Updates the current specifications of this collection
+   *
+   * @param specifications JSONObject Specifications content
+   * @param options Options Optional parameters
+   * @param listener Response callback
+   * @return Collection Kuzzle data collection
+   */
+  public Collection updateSpecifications(@NonNull final JSONObject specifications, final Options options, final ResponseListener<JSONObject> listener) throws JSONException {
+    if (specifications == null) {
+      throw new IllegalArgumentException("Collection.updateSpecifications: specifications cannot be null");
+    }
+
+    JSONObject data = new JSONObject()
+      .put("body", new JSONObject()
+        .put(this.getIndex(), new JSONObject()
+          .put(this.getCollection(), specifications)
+        )
+      );
+
+    try {
+      this.kuzzle.addHeaders(data, this.getHeaders());
+      this.kuzzle.query(makeQueryArgs("collection", "updateSpecifications"), data, options, new OnQueryDoneListener() {
+        @Override
+        public void onSuccess(JSONObject response) {
+          if (listener != null) {
+            try {
+              listener.onSuccess(response.getJSONObject("result"));
+            } catch (JSONException e) {
+              throw new RuntimeException(e);
+            }
+          }
+        }
+
+        @Override
+        public void onError(JSONObject error) {
+          if (listener != null) {
+            listener.onError(error);
+          }
+        }
+      });
+    } catch (JSONException e) {
+      throw new RuntimeException(e);
+    }
+
     return this;
   }
 

--- a/src/main/java/io/kuzzle/sdk/core/Collection.java
+++ b/src/main/java/io/kuzzle/sdk/core/Collection.java
@@ -1805,6 +1805,10 @@ public class Collection {
       throw new IllegalArgumentException("Collection.validateSpecifications: specifications cannot be null");
     }
 
+    if (listener == null) {
+      throw new IllegalArgumentException("listener cannot be null");
+    }
+
     JSONObject data = new JSONObject()
       .put("body", new JSONObject()
         .put(this.getIndex(), new JSONObject()

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/deleteSpecificationsTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/deleteSpecificationsTest.java
@@ -74,7 +74,7 @@ public class deleteSpecificationsTest {
         doAnswer(new Answer() {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {
-            ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(new JSONObject().put("result", new JSONObject().put("_id", "id-42")));
+            ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(new JSONObject().put("result", new JSONObject().put("acknowledged", true)));
             return null;
             }
         }).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));
@@ -87,7 +87,7 @@ public class deleteSpecificationsTest {
         doAnswer(new Answer() {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {
-            ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(new JSONObject().put("result", true));
+            ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(new JSONObject().put("result", new JSONObject().put("acknowledged", true)));
             ((OnQueryDoneListener) invocation.getArguments()[3]).onError(mock(JSONObject.class));
             return null;
             }
@@ -98,5 +98,4 @@ public class deleteSpecificationsTest {
         assertEquals(((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.getValue()).controller, "collection");
         assertEquals(((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.getValue()).action, "deleteSpecifications");
     }
-
 }

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/deleteSpecificationsTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/deleteSpecificationsTest.java
@@ -1,0 +1,102 @@
+package io.kuzzle.test.core.KuzzleDataCollection;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.net.URISyntaxException;
+
+import io.kuzzle.sdk.core.Kuzzle;
+import io.kuzzle.sdk.core.Options;
+import io.kuzzle.sdk.enums.Mode;
+import io.kuzzle.sdk.listeners.ResponseListener;
+import io.kuzzle.sdk.listeners.OnQueryDoneListener;
+import io.kuzzle.sdk.state.States;
+import io.kuzzle.test.testUtils.KuzzleDataCollectionExtend;
+import io.kuzzle.test.testUtils.KuzzleExtend;
+import io.socket.client.Socket;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class deleteSpecificationsTest {
+    private Kuzzle kuzzle;
+    private KuzzleDataCollectionExtend collection;
+    private ResponseListener listener;
+
+    @Before
+    public void setUp() throws URISyntaxException {
+        Options opts = new Options();
+        opts.setConnect(Mode.MANUAL);
+        KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
+        extended.setSocket(mock(Socket.class));
+        extended.setState(States.CONNECTED);
+
+        kuzzle = spy(extended);
+        when(kuzzle.getHeaders()).thenReturn(new JSONObject());
+
+        collection = new KuzzleDataCollectionExtend(kuzzle, "index", "test");
+        listener = mock(ResponseListener.class);
+    }
+
+    @Test
+    public void checkDeleteSpecificationsSignaturesVariants() throws JSONException {
+        Options opts = mock(Options.class);
+        collection = spy(collection);
+
+        collection.deleteSpecifications();
+        collection.deleteSpecifications(opts);
+        collection.deleteSpecifications(listener);
+        collection.deleteSpecifications(opts, listener);
+
+        verify(collection, times(4)).deleteSpecifications(any(Options.class), any(ResponseListener.class));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testDeleteSpecificationsQueryException() throws JSONException {
+        doThrow(JSONException.class).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));
+        collection.deleteSpecifications(listener);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testDeleteSpecificationsException() throws JSONException {
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+            ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(new JSONObject().put("result", new JSONObject().put("_id", "id-42")));
+            return null;
+            }
+        }).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));
+        doThrow(JSONException.class).when(listener).onSuccess(any(String.class));
+        collection.deleteSpecifications(listener);
+    }
+
+    @Test
+    public void testDeleteSpecifications() throws JSONException {
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+            ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(new JSONObject().put("result", new JSONObject()));
+            ((OnQueryDoneListener) invocation.getArguments()[3]).onError(mock(JSONObject.class));
+            return null;
+            }
+        }).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));
+        collection.deleteSpecifications(listener);
+        ArgumentCaptor argument = ArgumentCaptor.forClass(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class);
+        verify(kuzzle, times(1)).query((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.capture(), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));
+        assertEquals(((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.getValue()).controller, "collection");
+        assertEquals(((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.getValue()).action, "deleteSpecifications");
+    }
+
+}

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/deleteSpecificationsTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/deleteSpecificationsTest.java
@@ -87,7 +87,7 @@ public class deleteSpecificationsTest {
         doAnswer(new Answer() {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {
-            ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(new JSONObject().put("result", new JSONObject()));
+            ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(new JSONObject().put("result", true));
             ((OnQueryDoneListener) invocation.getArguments()[3]).onError(mock(JSONObject.class));
             return null;
             }

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/getSpecificationsTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/getSpecificationsTest.java
@@ -1,0 +1,113 @@
+package io.kuzzle.test.core.KuzzleDataCollection;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.net.URISyntaxException;
+
+import io.kuzzle.sdk.core.Collection;
+import io.kuzzle.sdk.core.Kuzzle;
+import io.kuzzle.sdk.core.Options;
+import io.kuzzle.sdk.enums.Mode;
+import io.kuzzle.sdk.listeners.ResponseListener;
+import io.kuzzle.sdk.listeners.OnQueryDoneListener;
+import io.kuzzle.sdk.state.States;
+import io.kuzzle.test.testUtils.KuzzleExtend;
+import io.socket.client.Socket;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class getSpecificationsTest {
+    private Kuzzle kuzzle;
+    private Collection collection;
+    private ResponseListener listener;
+
+    @Before
+    public void setUp() throws URISyntaxException {
+        Options opts = new Options();
+        opts.setConnect(Mode.MANUAL);
+        KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
+        extended.setSocket(mock(Socket.class));
+        extended.setState(States.CONNECTED);
+
+        kuzzle = spy(extended);
+        when(kuzzle.getHeaders()).thenReturn(new JSONObject());
+
+        collection = new Collection(kuzzle, "test", "index");
+        listener = mock(ResponseListener.class);
+    }
+
+    @Test
+    public void checkGetSpecificationsSignaturesVariants() throws JSONException {
+        collection = spy(collection);
+
+        collection.getSpecifications(mock(Options.class), listener);
+        collection.getSpecifications(listener);
+
+        verify(collection, times(2)).getSpecifications(any(Options.class), any(ResponseListener.class));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testGetSpecificationsQueryException() throws JSONException {
+        doThrow(JSONException.class).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));
+        collection.getSpecifications(listener);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testGetSpecificationsException() throws JSONException {
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+            ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(new JSONObject().put("result", new JSONObject()));
+            return null;
+            }
+        }).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));
+        doThrow(JSONException.class).when(listener).onSuccess(any(JSONObject.class));
+        collection.getSpecifications(listener);
+    }
+
+    @Test
+    public void testGetSpecifications() throws JSONException {
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+            ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(
+                new JSONObject()
+                    .put("result", new JSONObject()
+                        .put("validation", new JSONObject()
+                            .put("strict", true)
+                            .put("fields", new JSONObject()
+                                .put("foo", new JSONObject()
+                                    .put("mandatory", true)
+                                    .put("type", "string")
+                                    .put("defaultValue", "bar")
+                                )
+                            )
+                        )
+                    )
+            );
+            ((OnQueryDoneListener) invocation.getArguments()[3]).onError(mock(JSONObject.class));
+            return null;
+            }
+        }).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));
+        collection.getSpecifications(mock(ResponseListener.class));
+        collection.getSpecifications(new Options(), mock(ResponseListener.class));
+        ArgumentCaptor argument = ArgumentCaptor.forClass(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class);
+        verify(kuzzle, times(2)).query((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.capture(), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));
+        assertEquals(((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.getValue()).controller, "collection");
+        assertEquals(((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.getValue()).action, "getSpecifications");
+    }
+}

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/scrollSpecificationsTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/scrollSpecificationsTest.java
@@ -1,0 +1,167 @@
+package io.kuzzle.test.core.KuzzleDataCollection;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.net.URISyntaxException;
+
+import io.kuzzle.sdk.core.Collection;
+import io.kuzzle.sdk.core.Kuzzle;
+import io.kuzzle.sdk.core.Options;
+import io.kuzzle.sdk.enums.Mode;
+import io.kuzzle.sdk.listeners.OnQueryDoneListener;
+import io.kuzzle.sdk.listeners.ResponseListener;
+import io.kuzzle.sdk.state.States;
+import io.kuzzle.test.testUtils.KuzzleExtend;
+import io.socket.client.Socket;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class scrollSpecificationsTest {
+    private Kuzzle kuzzle;
+    private Collection collection;
+    private ResponseListener listener;
+    private String scrollId;
+    private Options options;
+
+    @Before
+    public void setUp() throws URISyntaxException {
+        Options opts = new Options();
+        opts.setConnect(Mode.MANUAL);
+        opts.setScroll("30s");
+        KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
+        extended.setSocket(mock(Socket.class));
+        extended.setState(States.CONNECTED);
+        kuzzle = spy(extended);
+        when(kuzzle.getHeaders()).thenReturn(new JSONObject());
+
+        collection = new Collection(kuzzle, "bar", "foo");
+        listener = mock(ResponseListener.class);
+        scrollId = "1337";
+        options = mock(Options.class);
+    }
+
+    @Test
+    public void checkScrollSpecificationsSignaturesVariants() {
+        collection = spy(collection);
+        collection.scrollSpecifications(scrollId, listener);
+        verify(collection).scrollSpecifications(eq(scrollId), any(Options.class), eq(listener));
+
+        collection.scrollSpecifications(scrollId, options, listener);
+        verify(collection).scrollSpecifications(eq(scrollId), eq(options), eq(listener));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testScrollSpecificationsIllegalListener() {
+        collection.scrollSpecifications(scrollId, null);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testScrollSpecificationsQueryException() throws JSONException {
+        doThrow(JSONException.class).when(kuzzle).query(any(Kuzzle.QueryArgs.class), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));
+        collection.scrollSpecifications(scrollId, listener);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testScrollSpecificationsException() throws JSONException {
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+            ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(new JSONObject().put("result", new JSONObject().put("count", 42)));
+            return null;
+            }
+        }).when(kuzzle).query(any(Kuzzle.QueryArgs.class), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));
+        doThrow(JSONException.class).when(listener).onSuccess(any(Integer.class));
+        collection.scrollSpecifications(scrollId, listener);
+    }
+
+    @Test
+    public void testScrollSpecifications() throws JSONException {
+        JSONObject filters = new JSONObject();
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                JSONObject response = new JSONObject("{\"result\": {\n" +
+                "    \"hits\": [\n" +
+                "      {\n" +
+                "        \"_id\": \"foo#bar\",\n" +
+                "        \"index\": \"foo\",\n" +
+                "        \"collection\": \"bar\",\n" +
+                "        \"_source\": {\n" +
+                "          \"validation\": {\n" +
+                "            \"strict\": true,\n" +
+                "            \"fields\": {\n" +
+                "              \"foo\": {\n" +
+                "                \"mandatory\": true,\n" +
+                "                \"type\": \"string\",\n" +
+                "                \"defaultValue\": \"bar\"\n" +
+                "              }\n" +
+                "            }\n" +
+                "          }\n" +
+                "        }\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"_id\": \"bar#foo\",\n" +
+                "        \"index\": \"bar\",\n" +
+                "        \"collection\": \"foo\",\n" +
+                "        \"_source\": {\n" +
+                "          \"validation\": {\n" +
+                "            \"strict\": false,\n" +
+                "            \"fields\": {\n" +
+                "              \"bar\": {\n" +
+                "                \"mandatory\": true,\n" +
+                "                \"type\": \"string\",\n" +
+                "                \"defaultValue\": \"foo\"\n" +
+                "              }\n" +
+                "            }\n" +
+                "          }\n" +
+                "        }\n" +
+                "      }\n" +
+                "    ],\n" +
+                "    \"total\": 2,\n" +
+                "    \"scrollId\": \"1337\"\n" +
+                "  }" +
+                "}");
+
+            ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(response);
+            ((OnQueryDoneListener) invocation.getArguments()[3]).onError(new JSONObject());
+            return null;
+            }
+        }).when(kuzzle).query(any(Kuzzle.QueryArgs.class), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));
+
+        collection.scrollSpecifications(scrollId, new ResponseListener<JSONObject>() {
+            @Override
+            public void onSuccess(JSONObject result) {
+                try {
+                    assertEquals(result.getJSONArray("hits").length(), 2);
+                    assertEquals(result.getJSONArray("hits").getJSONObject(1).getJSONObject("_source").getJSONObject("validation").getBoolean("strict"), false);
+                } catch (JSONException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            @Override
+            public void onError(JSONObject error) {
+            }
+        });
+        collection.scrollSpecifications(scrollId, mock(ResponseListener.class));
+        ArgumentCaptor argument = ArgumentCaptor.forClass(Kuzzle.QueryArgs.class);
+        verify(kuzzle, times(2)).query((Kuzzle.QueryArgs) argument.capture(), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));
+        assertEquals(((Kuzzle.QueryArgs) argument.getValue()).controller, "collection");
+        assertEquals(((Kuzzle.QueryArgs) argument.getValue()).action, "scrollSpecifications");
+    }
+}

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/searchSpecificationsTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/searchSpecificationsTest.java
@@ -1,0 +1,168 @@
+package io.kuzzle.test.core.KuzzleDataCollection;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.net.URISyntaxException;
+
+import io.kuzzle.sdk.core.Kuzzle;
+import io.kuzzle.sdk.core.Collection;
+import io.kuzzle.sdk.core.Options;
+import io.kuzzle.sdk.enums.Mode;
+import io.kuzzle.sdk.listeners.ResponseListener;
+import io.kuzzle.sdk.listeners.OnQueryDoneListener;
+import io.kuzzle.sdk.responses.SearchResult;
+import io.kuzzle.sdk.state.States;
+import io.kuzzle.test.testUtils.KuzzleExtend;
+import io.socket.client.Socket;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class searchSpecificationsTest {
+    private Kuzzle kuzzle;
+    private Collection collection;
+    private ResponseListener listener;
+
+    @Before
+    public void setUp() throws URISyntaxException {
+        Options opts = new Options();
+        opts.setConnect(Mode.MANUAL);
+        KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
+        extended.setSocket(mock(Socket.class));
+        extended.setState(States.CONNECTED);
+        kuzzle = spy(extended);
+        when(kuzzle.getHeaders()).thenReturn(new JSONObject());
+
+        collection = new Collection(kuzzle, "test", "index");
+        listener = mock(ResponseListener.class);
+    }
+
+    @Test
+    public void checkSearchSpecificationsSignaturesVariants() {
+        JSONObject filters = mock(JSONObject.class);
+        Options options = mock(Options.class);
+        collection = spy(collection);
+
+        collection.searchSpecifications(listener);
+        collection.searchSpecifications(filters, listener);
+        collection.searchSpecifications(options, listener);
+        collection.searchSpecifications(filters, options, listener);
+
+        verify(collection, times(4)).searchSpecifications(any(JSONObject.class), any(Options.class), any(ResponseListener.class));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSearchSpecificationsIllegalListener() {
+        collection.searchSpecifications(null, null, null);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testSearchSpecificationsQueryException() throws JSONException {
+        doThrow(JSONException.class).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));
+        collection.searchSpecifications(listener);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testSearchSpecificationsException() throws JSONException {
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+            ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(new JSONObject().put("result", new JSONObject()));
+            return null;
+            }
+        }).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));
+        doThrow(JSONException.class).when(listener).onSuccess(any(Integer.class));
+        collection.searchSpecifications(listener);
+    }
+
+    @Test
+    public void testSearchSpecifications() throws JSONException {
+        JSONObject filters = new JSONObject();
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                JSONObject response = new JSONObject("{\"result\": {\n" +
+                "    \"hits\": [\n" +
+                "      {\n" +
+                "        \"_id\": \"foo#bar\",\n" +
+                "        \"index\": \"foo\",\n" +
+                "        \"collection\": \"bar\",\n" +
+                "        \"_source\": {\n" +
+                "          \"validation\": {\n" +
+                "            \"strict\": true,\n" +
+                "            \"fields\": {\n" +
+                "              \"foo\": {\n" +
+                "                \"mandatory\": true,\n" +
+                "                \"type\": \"string\",\n" +
+                "                \"defaultValue\": \"bar\"\n" +
+                "              }\n" +
+                "            }\n" +
+                "          }\n" +
+                "        }\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"_id\": \"bar#foo\",\n" +
+                "        \"index\": \"bar\",\n" +
+                "        \"collection\": \"foo\",\n" +
+                "        \"_source\": {\n" +
+                "          \"validation\": {\n" +
+                "            \"strict\": false,\n" +
+                "            \"fields\": {\n" +
+                "              \"bar\": {\n" +
+                "                \"mandatory\": true,\n" +
+                "                \"type\": \"string\",\n" +
+                "                \"defaultValue\": \"foo\"\n" +
+                "              }\n" +
+                "            }\n" +
+                "          }\n" +
+                "        }\n" +
+                "      }\n" +
+                "    ],\n" +
+                "    \"total\": 2,\n" +
+                "    \"scrollId\": \"1337\"\n" +
+                "  }" +
+                "}");
+
+                ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(response);
+                ((OnQueryDoneListener) invocation.getArguments()[3]).onError(new JSONObject());
+                return null;
+            }
+        }).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));
+
+        collection.searchSpecifications(filters, new ResponseListener<JSONObject>() {
+            @Override
+            public void onSuccess(JSONObject result) {
+                try {
+                    assertEquals(result.getJSONArray("hits").length(), 2);
+                    assertEquals(result.getJSONArray("hits").getJSONObject(1).getJSONObject("_source").getJSONObject("validation").getBoolean("strict"), false);
+                    assertEquals(result.getString("scrollId"), "1337");
+                } catch (JSONException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            @Override
+            public void onError(JSONObject error) {
+            }
+        });
+        collection.searchSpecifications(filters, mock(ResponseListener.class));
+        ArgumentCaptor argument = ArgumentCaptor.forClass(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class);
+        verify(kuzzle, times(2)).query((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.capture(), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));
+        assertEquals(((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.getValue()).controller, "collection");
+        assertEquals(((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.getValue()).action, "searchSpecifications");
+    }
+}

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/updateSpecificationsTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/updateSpecificationsTest.java
@@ -1,0 +1,149 @@
+package io.kuzzle.test.core.KuzzleDataCollection;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.net.URISyntaxException;
+
+import io.kuzzle.sdk.core.Collection;
+import io.kuzzle.sdk.core.Kuzzle;
+import io.kuzzle.sdk.core.Options;
+import io.kuzzle.sdk.enums.Mode;
+import io.kuzzle.sdk.listeners.ResponseListener;
+import io.kuzzle.sdk.listeners.OnQueryDoneListener;
+import io.kuzzle.sdk.state.States;
+import io.kuzzle.test.testUtils.KuzzleExtend;
+import io.socket.client.Socket;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class updateSpecificationsTest {
+    private Kuzzle kuzzle;
+    private Collection collection;
+    private ResponseListener listener;
+
+    @Before
+    public void setUp() throws URISyntaxException {
+        Options opts = new Options();
+        opts.setConnect(Mode.MANUAL);
+        KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
+        extended.setSocket(mock(Socket.class));
+        extended.setState(States.CONNECTED);
+
+        kuzzle = spy(extended);
+        when(kuzzle.getHeaders()).thenReturn(new JSONObject());
+
+        collection = new Collection(kuzzle, "test", "index");
+        listener = mock(ResponseListener.class);
+    }
+
+    @Test
+    public void checkUpdateSpecificationsSignaturesVariants() throws JSONException {
+        JSONObject content = mock(JSONObject.class);
+        collection = spy(collection);
+
+        collection.updateSpecifications(content);
+        collection.updateSpecifications(content, mock(Options.class));
+        collection.updateSpecifications(content, listener);
+        collection.updateSpecifications(content, mock(Options.class), listener);
+
+        verify(collection, times(4)).updateSpecifications(any(JSONObject.class), any(Options.class), any(ResponseListener.class));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testUpdateSpecificationsIllegalArgument() throws JSONException {
+        collection.updateSpecifications(null);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testUpdateSpecificationsQueryException() throws JSONException {
+        doThrow(JSONException.class).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));
+        collection.updateSpecifications(mock(JSONObject.class), listener);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testUpdateSpecificationsException() throws JSONException {
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+            ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(new JSONObject().put("result", new JSONObject()));
+            return null;
+            }
+        }).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));
+        doThrow(JSONException.class).when(listener).onSuccess(any(JSONObject.class));
+        collection.updateSpecifications(mock(JSONObject.class), listener);
+    }
+
+    @Test
+    public void testUpdateSpecifications() throws JSONException {
+        final JSONObject specifications = new JSONObject()
+            .put("index", new JSONObject()
+                .put("test", new JSONObject()
+                    .put("strict", true)
+                    .put("fields", new JSONObject()
+                        .put("foo", new JSONObject()
+                            .put("mandatory", true)
+                            .put("type", "string")
+                            .put("defaultValue", "bar")
+                        )
+                    )
+                )
+            );
+
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+            JSONObject response = new JSONObject()
+                .put("result", specifications);
+            if (invocation.getArguments()[3] != null) {
+                ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(response);
+                ((OnQueryDoneListener) invocation.getArguments()[3]).onError(new JSONObject());
+            }
+            return null;
+            }
+        }).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));
+
+        collection.updateSpecifications(new JSONObject());
+        collection.updateSpecifications(new JSONObject(), new Options());
+        collection.updateSpecifications(new JSONObject(), new ResponseListener<JSONObject>() {
+            @Override
+            public void onSuccess(JSONObject response) {
+                assertEquals(response, specifications);
+                assertEquals(response, specifications);
+            }
+
+            @Override
+            public void onError(JSONObject error) {
+
+            }
+        });
+        collection.updateSpecifications(new JSONObject(), new Options(), new ResponseListener<JSONObject>() {
+            @Override
+            public void onSuccess(JSONObject response) {
+                assertEquals(response, specifications);
+            }
+
+            @Override
+            public void onError(JSONObject error) {
+
+            }
+        });
+        ArgumentCaptor argument = ArgumentCaptor.forClass(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class);
+        verify(kuzzle, times(4)).query((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.capture(), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));
+        assertEquals(((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.getValue()).controller, "collection");
+        assertEquals(((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.getValue()).action, "updateSpecifications");
+    }
+}

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/validateSpecificationsTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/validateSpecificationsTest.java
@@ -66,6 +66,11 @@ public class validateSpecificationsTest {
         collection.validateSpecifications(null, listener);
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testValidateSpecificationsIllegalListener() throws JSONException {
+        collection.validateSpecifications(null, null);
+    }
+
     @Test(expected = RuntimeException.class)
     public void testValidateSpecificationsQueryException() throws JSONException {
         doThrow(JSONException.class).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/validateSpecificationsTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/validateSpecificationsTest.java
@@ -1,0 +1,141 @@
+package io.kuzzle.test.core.KuzzleDataCollection;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.net.URISyntaxException;
+
+import io.kuzzle.sdk.core.Collection;
+import io.kuzzle.sdk.core.Kuzzle;
+import io.kuzzle.sdk.core.Options;
+import io.kuzzle.sdk.enums.Mode;
+import io.kuzzle.sdk.listeners.ResponseListener;
+import io.kuzzle.sdk.listeners.OnQueryDoneListener;
+import io.kuzzle.sdk.state.States;
+import io.kuzzle.test.testUtils.KuzzleExtend;
+import io.socket.client.Socket;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class validateSpecificationsTest {
+    private Kuzzle kuzzle;
+    private Collection collection;
+    private ResponseListener listener;
+
+    @Before
+    public void setUp() throws URISyntaxException {
+        Options opts = new Options();
+        opts.setConnect(Mode.MANUAL);
+        KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
+        extended.setSocket(mock(Socket.class));
+        extended.setState(States.CONNECTED);
+
+        kuzzle = spy(extended);
+        when(kuzzle.getHeaders()).thenReturn(new JSONObject());
+
+        collection = new Collection(kuzzle, "test", "index");
+        listener = mock(ResponseListener.class);
+    }
+
+    @Test
+    public void checkValidateSpecificationsSignaturesVariants() throws JSONException {
+        JSONObject specifications = mock(JSONObject.class);
+        collection = spy(collection);
+
+        collection.validateSpecifications(specifications, listener);
+        collection.validateSpecifications(specifications, mock(Options.class), listener);
+
+        verify(collection, times(2)).validateSpecifications(any(JSONObject.class), any(Options.class), any(ResponseListener.class));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testValidateSpecificationsIllegalArgument() throws JSONException {
+        collection.validateSpecifications(null, listener);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testValidateSpecificationsQueryException() throws JSONException {
+        doThrow(JSONException.class).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));
+        collection.validateSpecifications(mock(JSONObject.class), listener);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testValidateSpecificationsException() throws JSONException {
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(new JSONObject().put("result", new JSONObject().put("valid", true)));
+                return null;
+            }
+        }).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));
+        doThrow(JSONException.class).when(listener).onSuccess(any(JSONObject.class));
+        collection.validateSpecifications(mock(JSONObject.class), listener);
+    }
+
+    @Test
+    public void testValidateSpecifications() throws JSONException {
+        final JSONObject validateSpecificationsResponse = new JSONObject().put("valid", true);
+
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+            JSONObject response = new JSONObject()
+                .put("result", validateSpecificationsResponse);
+            if (invocation.getArguments()[3] != null) {
+                ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(response);
+                ((OnQueryDoneListener) invocation.getArguments()[3]).onError(new JSONObject());
+            }
+            return null;
+            }
+        }).when(kuzzle).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));
+
+        collection.validateSpecifications(new JSONObject(), new ResponseListener<Boolean>() {
+            @Override
+            public void onSuccess(Boolean isValid) {
+                try {
+                    assertEquals(isValid, validateSpecificationsResponse.getBoolean("valid"));
+                    assertEquals(isValid, validateSpecificationsResponse.getBoolean("valid"));
+                } catch (JSONException e) {
+                    e.printStackTrace();
+                }
+            }
+
+            @Override
+            public void onError(JSONObject error) {
+
+            }
+        });
+        collection.validateSpecifications(new JSONObject(), new Options(), new ResponseListener<Boolean>() {
+            @Override
+            public void onSuccess(Boolean isValid) {
+                try {
+                    assertEquals(isValid, validateSpecificationsResponse.getBoolean("valid"));
+                } catch (JSONException e) {
+                    e.printStackTrace();
+                }
+            }
+
+            @Override
+            public void onError(JSONObject error) {
+
+            }
+        });
+        ArgumentCaptor argument = ArgumentCaptor.forClass(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class);
+        verify(kuzzle, times(2)).query((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.capture(), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));
+        assertEquals(((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.getValue()).controller, "collection");
+        assertEquals(((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.getValue()).action, "validateSpecifications");
+    }
+}


### PR DESCRIPTION
fix kuzzleio/kuzzle-sdk#3

# Introduces
- Specifications CRUDL routes (get - search - scroll - update - delete - validate) and related unit tests