### PR TITLE
Add SDK version into volatile

### DIFF
--- a/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
+++ b/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
@@ -1,7 +1,6 @@
 package io.kuzzle.sdk.core;
 
 import android.support.annotation.NonNull;
-import android.util.Log;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
@@ -39,6 +38,7 @@ import io.kuzzle.sdk.util.EventList;
 import io.kuzzle.sdk.util.OfflineQueueLoader;
 import io.kuzzle.sdk.util.QueryObject;
 import io.kuzzle.sdk.util.QueueFilter;
+import io.kuzzle.sdk_android.BuildConfig;
 import io.socket.client.IO;
 import io.socket.client.Socket;
 import io.socket.emitter.Emitter;
@@ -1360,6 +1360,7 @@ public class Kuzzle {
       }
     }
 
+    _volatile.put("sdkVersion", this.getSdkVersion());
     object.put("volatile", _volatile);
 
     if (queryArgs.collection != null) {
@@ -1705,6 +1706,15 @@ public class Kuzzle {
    */
   public JSONObject getHeaders() {
     return this.headers;
+  }
+
+  /**
+   * Returns the current SDK version.
+   *
+   * @return String
+   */
+  public String getSdkVersion() {
+    return BuildConfig.VERSION_NAME;
   }
 
   /**

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/queryTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/queryTest.java
@@ -81,7 +81,7 @@ public class queryTest {
     JSONObject request = (JSONObject) argument.getValue();
     assertEquals(request.getString("controller"), args.controller);
     assertEquals(request.getString("action"), args.action);
-    assertEquals(request.getJSONObject("volatile").length(), 0);
+    assertEquals(request.getJSONObject("volatile").length(), 1);
     assertEquals(request.has("index"), false);
     assertEquals(request.has("collection"), false);
     assertEquals(request.has("headers"), false);
@@ -102,7 +102,7 @@ public class queryTest {
     assertEquals(request.getString("index"), args.index);
     assertEquals(request.has("collection"), false);
     assertEquals(request.has("headers"), false);
-    assertEquals(request.getJSONObject("volatile").length(), 0);
+    assertEquals(request.getJSONObject("volatile").length(), 1);
     assertNotNull(request.getString("requestId"));
   }
 
@@ -120,7 +120,7 @@ public class queryTest {
     assertEquals(request.getString("collection"), args.collection);
     assertEquals(request.has("index"), false);
     assertEquals(request.has("headers"), false);
-    assertEquals(request.getJSONObject("volatile").length(), 0);
+    assertEquals(request.getJSONObject("volatile").length(), 1);
     assertNotNull(request.getString("requestId"));
   }
 
@@ -135,7 +135,7 @@ public class queryTest {
     JSONObject request = (JSONObject) argument.getValue();
     assertEquals(request.getString("controller"), args.controller);
     assertEquals(request.getString("action"), args.action);
-    assertEquals(request.getJSONObject("volatile").length(), 0);
+    assertEquals(request.getJSONObject("volatile").length(), 1);
     assertEquals(request.has("index"), false);
     assertEquals(request.has("collection"), false);
     assertNotNull(request.getString("requestId"));
@@ -155,7 +155,7 @@ public class queryTest {
     JSONObject request = (JSONObject) argument.getValue();
     assertEquals(request.getString("controller"), args.controller);
     assertEquals(request.getString("action"), args.action);
-    assertEquals(request.getJSONObject("volatile").length(), 0);
+    assertEquals(request.getJSONObject("volatile").length(), 1);
     assertEquals(request.has("index"), false);
     assertEquals(request.has("collection"), false);
     assertEquals(request.has("headers"), false);
@@ -176,10 +176,23 @@ public class queryTest {
     verify(socket).emit(any(String.class), (JSONObject) argument.capture());
 
     JSONObject _volatile = ((JSONObject) argument.getValue()).getJSONObject("volatile");
-    assertEquals(_volatile.length(), 3);
+    assertEquals(_volatile.length(), 4);
+    assertEquals(_volatile.getString("sdkVersion"), kuzzle.getSdkVersion());
     assertEquals(_volatile.getString("foo"), "bar"); // options take precedence over kuzzle volatile data
     assertEquals(_volatile.getString("bar"), "bar");
     assertEquals(_volatile.getString("qux"), "qux");
+  }
+
+  @Test
+  public void shouldSendSdkVersionInVolatile() throws JSONException  {
+    kuzzle.query(args, new JSONObject(), new Options());
+
+    ArgumentCaptor argument = ArgumentCaptor.forClass(JSONObject.class);
+    verify(socket).emit(any(String.class), (JSONObject) argument.capture());
+
+    JSONObject _volatile = ((JSONObject) argument.getValue()).getJSONObject("volatile");
+    assertEquals(_volatile.length(), 1);
+    assertEquals(_volatile.getString("sdkVersion"), kuzzle.getSdkVersion());
   }
 
   @Test


### PR DESCRIPTION
- Adds the current version of the SDK into volatile for every Kuzzle query.