### PR TITLE
Rename jwtTokenExpired to tokenExpired

### DIFF
--- a/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
+++ b/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
@@ -474,7 +474,7 @@ public class Kuzzle {
               public void onSuccess(TokenValidity response) {
                 if (!response.isValid()) {
                   Kuzzle.this.jwtToken = null;
-                  Kuzzle.this.emitEvent(Event.jwtTokenExpired);
+                  Kuzzle.this.emitEvent(Event.tokenExpired);
                 }
 
                 Kuzzle.this.reconnect();
@@ -483,7 +483,7 @@ public class Kuzzle {
               @Override
               public void onError(JSONObject error) {
                 Kuzzle.this.jwtToken = null;
-                Kuzzle.this.emitEvent(Event.jwtTokenExpired);
+                Kuzzle.this.emitEvent(Event.tokenExpired);
                 Kuzzle.this.reconnect();
               }
             });
@@ -1609,7 +1609,7 @@ public class Kuzzle {
           try {
             // checking token expiration
             if (!((JSONObject) args[0]).isNull("error") && ((JSONObject) args[0]).getJSONObject("error").getString("message").equals("Token expired") && !((JSONObject) args[0]).getString("action").equals("logout")) {
-              emitEvent(Event.jwtTokenExpired, listener);
+              emitEvent(Event.tokenExpired, listener);
             }
 
             if (listener != null) {

--- a/src/main/java/io/kuzzle/sdk/core/Room.java
+++ b/src/main/java/io/kuzzle/sdk/core/Room.java
@@ -202,32 +202,23 @@ public class Room {
     }
 
     try {
-      if (!((JSONObject) args).isNull("error")) {
-        listener.onError((JSONObject) args);
+      String key = ((JSONObject) args).getString("requestId");
+
+      if (((JSONObject) args).getString("type").equals("TokenExpired")) {
+        Room.this.kuzzle.jwtToken = null;
+        Room.this.kuzzle.emitEvent(Event.tokenExpired);
       }
-      else {
-        String key = ((JSONObject) args).getString("requestId");
 
-        if (((JSONObject) args).getString("action").equals("jwtTokenExpired")) {
-          Room.this.kuzzle.jwtToken = null;
-          Room.this.kuzzle.emitEvent(Event.jwtTokenExpired);
-        }
-
-        if (Room.this.kuzzle.getRequestHistory().containsKey(key)) {
-          if (Room.this.subscribeToSelf) {
-            listener.onSuccess(new NotificationResponse(kuzzle, (JSONObject) args));
-          }
-          Room.this.kuzzle.getRequestHistory().remove(key);
-        } else {
+      if (Room.this.kuzzle.getRequestHistory().containsKey(key)) {
+        if (Room.this.subscribeToSelf) {
           listener.onSuccess(new NotificationResponse(kuzzle, (JSONObject) args));
         }
+        Room.this.kuzzle.getRequestHistory().remove(key);
+      } else {
+        listener.onSuccess(new NotificationResponse(kuzzle, (JSONObject) args));
       }
     } catch (JSONException e) {
-      try {
-        listener.onError(((JSONObject) args).getJSONObject("error"));
-      } catch (JSONException err) {
-        throw new RuntimeException(e);
-      }
+      throw new RuntimeException(e);
     }
   }
 

--- a/src/main/java/io/kuzzle/sdk/enums/Event.java
+++ b/src/main/java/io/kuzzle/sdk/enums/Event.java
@@ -8,7 +8,7 @@ public enum Event {
   reconnected,
   connected,
   error,
-  jwtTokenExpired,
+  tokenExpired,
   loginAttempt,
   offlineQueuePush,
   offlineQueuePop

--- a/src/main/java/io/kuzzle/sdk/responses/NotificationResponse.java
+++ b/src/main/java/io/kuzzle/sdk/responses/NotificationResponse.java
@@ -12,7 +12,6 @@ import io.kuzzle.sdk.enums.Users;
 
 public class NotificationResponse {
   private int status;
-  private JSONObject error;
   private String  index;
   private String  collection;
   private String  controller;
@@ -28,14 +27,13 @@ public class NotificationResponse {
   public NotificationResponse(final Kuzzle kuzzle, final JSONObject object) {
     try {
       this.status = object.getInt("status");
-      this.error = (object.isNull("error") ? null : object.getJSONObject("error"));
       this.index = object.getString("index");
       this.collection = object.getString("collection");
       this.controller = object.getString("controller");
       this.action = object.getString("action");
       this.state = (object.isNull("state") ? null : State.valueOf(object.getString("state").toUpperCase()));
       this._volatile = object.getJSONObject("volatile");
-      this.requestId = object.getString("requestId");
+      this.requestId = object.isNull("requestId") ? null : object.getString("requestId");
       this.result = (object.isNull("result") ? null : object.getJSONObject("result"));
       this.scope = (object.isNull("scope") ? null : Scope.valueOf(object.getString("scope").toUpperCase()));
       this.users = (object.isNull("user") ? null : Users.valueOf(object.getString("user").toUpperCase()));
@@ -50,10 +48,6 @@ public class NotificationResponse {
 
   public int getStatus() {
     return status;
-  }
-
-  public JSONObject getError() {
-    return error;
   }
 
   public String getIndex() {

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/queryTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/queryTest.java
@@ -254,14 +254,14 @@ public class queryTest {
   }
 
   @Test
-  public void shouldTriggerJwtTokenExpiredEvent() throws JSONException {
+  public void shouldTriggerTokenExpiredEvent() throws JSONException {
     EventListener fake = spy(new EventListener() {
       @Override
       public void trigger(Object... args) {
 
       }
     });
-    kuzzle.addListener(Event.jwtTokenExpired, fake);
+    kuzzle.addListener(Event.tokenExpired, fake);
     doAnswer(new Answer() {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {

--- a/src/test/java/io/kuzzle/test/core/KuzzleRoom/notificationHandlerTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleRoom/notificationHandlerTest.java
@@ -50,8 +50,8 @@ public class notificationHandlerTest {
       .put("collection", "collection")
       .put("controller", "controller")
       .put("action", "action")
-      .put("state", "ALL")
-      .put("scope", "ALL")
+      .put("state", "all")
+      .put("scope", "all")
       .put("volatile", new JSONObject())
       .put("result", new JSONObject())
       .put("requestId", "42");
@@ -66,17 +66,6 @@ public class notificationHandlerTest {
     RoomExtend renew = new RoomExtend(new Collection(k, "test", "index"));
     // Should throw an exception
     renew.callAfterRenew(null);
-  }
-
-  @Test
-  public void testCallAfterRenewWithError() throws JSONException {
-    RoomExtend renew = new RoomExtend(new Collection(k, "test", "index"));
-    JSONObject errorResponse = new JSONObject();
-    errorResponse.put("error", "error");
-    ResponseListener listener = mock(ResponseListener.class);
-    renew.setListener(listener);
-    renew.callAfterRenew(errorResponse);
-    verify(listener, atLeastOnce()).onError(any(JSONObject.class));
   }
 
   @Test
@@ -144,7 +133,7 @@ public class notificationHandlerTest {
   }
 
   @Test
-  public void testJwtTokenExpiredNotification() throws JSONException, URISyntaxException {
+  public void testTokenExpiredNotification() throws JSONException, URISyntaxException {
     k = new Kuzzle("localhost");
     EventListener listener = spy(new EventListener() {
       @Override
@@ -152,12 +141,12 @@ public class notificationHandlerTest {
 
       }
     });
-    k.addListener(Event.jwtTokenExpired, listener);
+    k.addListener(Event.tokenExpired, listener);
     RoomExtend renew = new RoomExtend(new Collection(k, "test", "index"));
     renew.setListener(mock(ResponseListener.class));
     JSONObject mockResponse = new JSONObject().put("result", new JSONObject());
     mockResponse.put("requestId", "42");
-    mockNotif.put("action", "jwtTokenExpired");
+    mockNotif.put("type", "TokenExpired");
     renew.callAfterRenew(mockNotif);
     verify(listener, times(1)).trigger();
   }


### PR DESCRIPTION
# Description

Rename all instances of the `jwtTokenExpired` event to `tokenExpired`.
Also adapt to the new notifications format (see https://github.com/kuzzleio/kuzzle/pull/882 )