### PR TITLE
Add meta to Security documents (User, Profile, Role)

### DIFF
--- a/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
+++ b/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
@@ -2152,7 +2152,7 @@ public class Kuzzle {
         public void onSuccess(JSONObject response) {
           try {
             JSONObject result = response.getJSONObject("result");
-            listener.onSuccess(new User(Kuzzle.this, result.getString("_id"), result.getJSONObject("_source")));
+            listener.onSuccess(new User(Kuzzle.this, result.getString("_id"), result.getJSONObject("_source"), result.getJSONObject("_meta")));
           } catch (JSONException e) {
             throw new RuntimeException(e);
           }

--- a/src/main/java/io/kuzzle/sdk/security/AbstractSecurityDocument.java
+++ b/src/main/java/io/kuzzle/sdk/security/AbstractSecurityDocument.java
@@ -20,6 +20,7 @@ public class AbstractSecurityDocument {
   protected String  updateActionName;
   public final String id;
   public JSONObject content;
+  public JSONObject meta;
 
   /**
    * Instantiates a new Abstract kuzzle security document.
@@ -29,7 +30,7 @@ public class AbstractSecurityDocument {
    * @param content Security document content
    * @throws JSONException 
    */
-  public AbstractSecurityDocument(final Kuzzle kuzzle, @NonNull final String id, final JSONObject content) throws JSONException {
+  public AbstractSecurityDocument(final Kuzzle kuzzle, @NonNull final String id, final JSONObject content, final JSONObject meta) throws JSONException {
     if (id == null) {
       throw new IllegalArgumentException("Cannot initialize with a null ID");
     }
@@ -42,6 +43,12 @@ public class AbstractSecurityDocument {
       setContent(content);
     } else {
       this.content = new JSONObject();
+    }
+
+    if (meta != null) {
+      setMeta(meta);
+    } else {
+      this.meta = new JSONObject();
     }
   }
 
@@ -58,6 +65,23 @@ public class AbstractSecurityDocument {
     }
 
     this.content = new JSONObject(content.toString());
+
+    return this;
+  }
+
+  /**
+   * Sets the metadata of this object
+   *
+   * @param meta New metadata
+   * @return this
+   * @throws JSONException
+   */
+  public AbstractSecurityDocument setMeta(@NonNull final JSONObject meta) throws JSONException {
+    if (meta == null) {
+      throw new IllegalArgumentException("AbstractSecurityDocument.setMeta: cannot set null metadata");
+    }
+
+    this.meta = new JSONObject(meta.toString());
 
     return this;
   }
@@ -147,6 +171,15 @@ public class AbstractSecurityDocument {
    */
   public JSONObject getContent() {
     return this.content;
+  }
+
+  /**
+   * Getter for the "meta" property
+   *
+   * @return the document metadata
+   */
+  public JSONObject getMeta() {
+    return this.meta;
   }
 
   /**

--- a/src/main/java/io/kuzzle/sdk/security/Profile.java
+++ b/src/main/java/io/kuzzle/sdk/security/Profile.java
@@ -26,10 +26,11 @@ public class Profile extends AbstractSecurityDocument {
    * @param kuzzle  Kuzzle instance to attach
    * @param id      Profile unique ID
    * @param content Profile content
+   * @param meta Profile metadata
    * @throws JSONException 
    */
-  public Profile(final Kuzzle kuzzle, @NonNull final String id, final JSONObject content) throws JSONException {
-    super(kuzzle, id, null);
+  public Profile(final Kuzzle kuzzle, @NonNull final String id, final JSONObject content, final JSONObject meta) throws JSONException {
+    super(kuzzle, id, null, meta);
     this.deleteActionName = "deleteProfile";
     this.updateActionName = "updateProfile";
 

--- a/src/main/java/io/kuzzle/sdk/security/Role.java
+++ b/src/main/java/io/kuzzle/sdk/security/Role.java
@@ -1,6 +1,5 @@
 package io.kuzzle.sdk.security;
 
-
 import android.support.annotation.NonNull;
 
 import org.json.JSONException;
@@ -21,10 +20,11 @@ public class Role extends AbstractSecurityDocument {
    * @param kuzzle  Kuzzle instance to attach
    * @param id      Role unique identifier
    * @param content Role content
+   * @param meta Role metadata
    * @throws JSONException 
    */
-  public Role(final Kuzzle kuzzle, @NonNull final String id, final JSONObject content) throws JSONException {
-    super(kuzzle, id, content);
+  public Role(final Kuzzle kuzzle, @NonNull final String id, final JSONObject content, final JSONObject meta) throws JSONException {
+    super(kuzzle, id, content, meta);
     this.deleteActionName = "deleteRole";
     this.updateActionName = "updateRole";
   }

--- a/src/main/java/io/kuzzle/sdk/security/Security.java
+++ b/src/main/java/io/kuzzle/sdk/security/Security.java
@@ -17,7 +17,6 @@ import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.responses.SecurityDocumentList;
 import io.kuzzle.sdk.util.Scroll;
 
-
 /**
  * Kuzzle security API
  */
@@ -75,12 +74,12 @@ public class Security {
 
     try {
       data = new JSONObject().put("_id", id);
-      this.kuzzle.query(buildQueryArgs("fetchRole"), data, options, new OnQueryDoneListener() {
+      this.kuzzle.query(buildQueryArgs("getRole"), data, options, new OnQueryDoneListener() {
         @Override
         public void onSuccess(JSONObject response) {
           try {
             JSONObject result = response.getJSONObject("result");
-            listener.onSuccess(new Role(Security.this.kuzzle, result.getString("_id"), result.getJSONObject("_source")));
+            listener.onSuccess(new Role(Security.this.kuzzle, result.getString("_id"), result.getJSONObject("_source"), result.getJSONObject("_meta")));
           }
           catch (JSONException e) {
             throw new RuntimeException(e);
@@ -135,7 +134,7 @@ public class Security {
 
           for (int i = 0; i < documentsLength; i++) {
             JSONObject document = documents.getJSONObject(i);
-            roles.add(new Role(Security.this.kuzzle, document.getString("_id"), document.getJSONObject("_source")));
+            roles.add(new Role(Security.this.kuzzle, document.getString("_id"), document.getJSONObject("_source"), document.getJSONObject("_meta")));
           }
 
           listener.onSuccess(new SecurityDocumentList(roles, result.getLong("total")));
@@ -188,7 +187,7 @@ public class Security {
         public void onSuccess(JSONObject response) {
           try {
             JSONObject result = response.getJSONObject("result");
-            listener.onSuccess(new Role(Security.this.kuzzle, result.getString("_id"), result.getJSONObject("_source")));
+            listener.onSuccess(new Role(Security.this.kuzzle, result.getString("_id"), result.getJSONObject("_source"), result.getJSONObject("_meta")));
           }
           catch(JSONException e) {
             throw new RuntimeException(e);
@@ -312,7 +311,7 @@ public class Security {
         @Override
         public void onSuccess(JSONObject response) {
           try {
-            listener.onSuccess(new Role(Security.this.kuzzle, response.getJSONObject("result").getString("_id"), response.getJSONObject("result").getJSONObject("_source")));
+            listener.onSuccess(new Role(Security.this.kuzzle, response.getJSONObject("result").getString("_id"), response.getJSONObject("result").getJSONObject("_source"), response.getJSONObject("result").getJSONObject("_meta")));
           }
           catch(JSONException e) {
             throw new RuntimeException(e);
@@ -359,18 +358,26 @@ public class Security {
    *
    * @param id Role unique identifier
    * @param content Role content
+   * @param meta Role metadata
    * @return new Role object
    * @throws JSONException 
    */
-  public Role role(@NonNull final String id, final JSONObject content) throws JSONException {
-    return new Role(this.kuzzle, id, content);
+  public Role role(@NonNull final String id, final JSONObject content, final JSONObject meta) throws JSONException {
+    return new Role(this.kuzzle, id, content, meta);
   }
 
   /**
-   * {@link #role(String, JSONObject)}
+   * {@link #role(String, JSONObject, JSONObject)}
+   */
+  public Role role(@NonNull final String id, final JSONObject content) throws JSONException {
+    return new Role(this.kuzzle, id, content, null);
+  }
+
+  /**
+   * {@link #role(String, JSONObject, JSONObject)}
    */
   public Role role(@NonNull final String id) throws JSONException {
-    return new Role(this.kuzzle, id, null);
+    return new Role(this.kuzzle, id, null, null);
   }
 
   /**
@@ -392,7 +399,7 @@ public class Security {
 
     JSONObject data = new JSONObject().put("_id", id);
 
-    this.kuzzle.query(buildQueryArgs("fetchProfile"), data, options, new OnQueryDoneListener() {
+    this.kuzzle.query(buildQueryArgs("getProfile"), data, options, new OnQueryDoneListener() {
       @Override
       public void onSuccess(JSONObject response) {
         try {
@@ -415,7 +422,7 @@ public class Security {
           result.getJSONObject("_source").remove("policies");
           result.getJSONObject("_source").put("policies", formattedPolicies);
 
-          listener.onSuccess(new Profile(Security.this.kuzzle, result.getString("_id"), result.getJSONObject("_source")));
+          listener.onSuccess(new Profile(Security.this.kuzzle, result.getString("_id"), result.getJSONObject("_source"), result.getJSONObject("_meta")));
         } catch (JSONException e) {
           throw new RuntimeException(e);
         }
@@ -465,7 +472,7 @@ public class Security {
 
           for (int i = 0; i < documentsLength; i++) {
             JSONObject document = documents.getJSONObject(i);
-            profiles.add(new Profile(Security.this.kuzzle, document.getString("_id"), document.getJSONObject("_source")));
+            profiles.add(new Profile(Security.this.kuzzle, document.getString("_id"), document.getJSONObject("_source"), document.getJSONObject("_meta")));
           }
 
           Scroll scroll = new Scroll();
@@ -526,7 +533,7 @@ public class Security {
         public void onSuccess(JSONObject response) {
           try {
             JSONObject result = response.getJSONObject("result");
-            listener.onSuccess(new Profile(Security.this.kuzzle, result.getString("_id"), result.getJSONObject("_source")));
+            listener.onSuccess(new Profile(Security.this.kuzzle, result.getString("_id"), result.getJSONObject("_source"), result.getJSONObject("_meta")));
           }
           catch(JSONException e) {
             throw new RuntimeException(e);
@@ -665,7 +672,7 @@ public class Security {
 
             for (int i = 0; i < hits.length(); i++) {
               JSONObject hit = hits.getJSONObject(i);
-              Profile profile = new Profile(Security.this.kuzzle, hit.getString("_id"), hit.getJSONObject("_source"));
+              Profile profile = new Profile(Security.this.kuzzle, hit.getString("_id"), hit.getJSONObject("_source"), hit.getJSONObject("_meta"));
 
               profiles.add(profile);
             }
@@ -718,7 +725,7 @@ public class Security {
         @Override
         public void onSuccess(JSONObject response) {
           try {
-            listener.onSuccess(new Profile(Security.this.kuzzle, response.getJSONObject("result").getString("_id"), response.getJSONObject("result").getJSONObject("_source")));
+            listener.onSuccess(new Profile(Security.this.kuzzle, response.getJSONObject("result").getString("_id"), response.getJSONObject("result").getJSONObject("_source"), response.getJSONObject("result").getJSONObject("_meta")));
           }
           catch(JSONException e) {
             throw new RuntimeException(e);
@@ -765,18 +772,26 @@ public class Security {
    *
    * @param id Profile unique identifier
    * @param content Profile content
+   * @param meta Profile metadata
    * @return new Profile object
    * @throws JSONException 
    */
-  public Profile profile(@NonNull final String id, final JSONObject content) throws JSONException {
-    return new Profile(this.kuzzle, id, content);
+  public Profile profile(@NonNull final String id, final JSONObject content, final JSONObject meta) throws JSONException {
+    return new Profile(this.kuzzle, id, content, meta);
   }
 
   /**
-   * {@link #profile(String, JSONObject)}
+   * {@link #profile(String, JSONObject, JSONObject)}
+   */
+  public Profile profile(@NonNull final String id, final JSONObject content) throws JSONException {
+    return new Profile(this.kuzzle, id, content, null);
+  }
+
+  /**
+   * {@link #profile(String, JSONObject, JSONObject)}
    */
   public Profile profile(@NonNull final String id) throws JSONException {
-    return new Profile(this.kuzzle, id, null);
+    return new Profile(this.kuzzle, id, null, null);
   }
 
   /**
@@ -798,12 +813,12 @@ public class Security {
 
     JSONObject data = new JSONObject().put("_id", id);
 
-    this.kuzzle.query(buildQueryArgs("fetchUser"), data, options, new OnQueryDoneListener() {
+    this.kuzzle.query(buildQueryArgs("getUser"), data, options, new OnQueryDoneListener() {
       @Override
       public void onSuccess(JSONObject response) {
         try {
           JSONObject result = response.getJSONObject("result");
-          listener.onSuccess(new User(Security.this.kuzzle, result.getString("_id"), result.getJSONObject("_source")));
+          listener.onSuccess(new User(Security.this.kuzzle, result.getString("_id"), result.getJSONObject("_source"), result.getJSONObject("_meta")));
         } catch (JSONException e) {
           throw new RuntimeException(e);
         }
@@ -849,7 +864,7 @@ public class Security {
         public void onSuccess(JSONObject response) {
           try {
             JSONObject result = response.getJSONObject("result");
-            listener.onSuccess(new User(Security.this.kuzzle, result.getString("_id"), result.getJSONObject("_source")));
+            listener.onSuccess(new User(Security.this.kuzzle, result.getString("_id"), result.getJSONObject("_source"), result.getJSONObject("_meta")));
           }
           catch (JSONException e) {
             throw new RuntimeException(e);
@@ -919,7 +934,7 @@ public class Security {
 
           for (int i = 0; i < documentsLength; i++) {
             JSONObject document = documents.getJSONObject(i);
-            users.add(new User(Security.this.kuzzle, document.getString("_id"), document.getJSONObject("_source")));
+            users.add(new User(Security.this.kuzzle, document.getString("_id"), document.getJSONObject("_source"), document.getJSONObject("_meta")));
           }
 
           Scroll scroll = new Scroll();
@@ -971,7 +986,7 @@ public class Security {
         public void onSuccess(JSONObject response) {
           try {
             JSONObject result = response.getJSONObject("result");
-            listener.onSuccess(new User(Security.this.kuzzle, result.getString("_id"), result.getJSONObject("_source")));
+            listener.onSuccess(new User(Security.this.kuzzle, result.getString("_id"), result.getJSONObject("_source"), result.getJSONObject("_meta")));
           }
           catch (JSONException e) {
             throw new RuntimeException(e);
@@ -1039,7 +1054,7 @@ public class Security {
         public void onSuccess(JSONObject response) {
           try {
             JSONObject result = response.getJSONObject("result");
-            listener.onSuccess(new User(Security.this.kuzzle, result.getString("_id"), result.getJSONObject("_source")));
+            listener.onSuccess(new User(Security.this.kuzzle, result.getString("_id"), result.getJSONObject("_source"), result.getJSONObject("_meta")));
           }
           catch (JSONException e) {
             throw new RuntimeException(e);
@@ -1178,7 +1193,7 @@ public class Security {
 
             for (int i = 0; i < hits.length(); i++) {
               JSONObject hit = hits.getJSONObject(i);
-              User user = new User(Security.this.kuzzle, hit.getString("_id"), hit.getJSONObject("_source"));
+              User user = new User(Security.this.kuzzle, hit.getString("_id"), hit.getJSONObject("_source"), hit.getJSONObject("_meta"));
 
               users.add(user);
             }
@@ -1231,7 +1246,7 @@ public class Security {
         @Override
         public void onSuccess(JSONObject response) {
           try {
-            listener.onSuccess(new User(Security.this.kuzzle, response.getJSONObject("result").getString("_id"), response.getJSONObject("result").getJSONObject("_source")));
+            listener.onSuccess(new User(Security.this.kuzzle, response.getJSONObject("result").getString("_id"), response.getJSONObject("result").getJSONObject("_source"), response.getJSONObject("result").getJSONObject("_meta")));
           }
           catch(JSONException e) {
             throw new RuntimeException(e);
@@ -1278,18 +1293,26 @@ public class Security {
    *
    * @param id      User unique identifier
    * @param content User content
+   * @param meta    User metadata
    * @return new User object
    * @throws JSONException 
    */
-  public User user(@NonNull final String id, final JSONObject content) throws JSONException {
-    return new User(this.kuzzle, id, content);
+  public User user(@NonNull final String id, final JSONObject content, final JSONObject meta) throws JSONException {
+    return new User(this.kuzzle, id, content, meta);
   }
 
   /**
-   * {@link #user(String, JSONObject)}
+   * {@link #user(String, JSONObject, JSONObject)}
+   */
+  public User user(@NonNull final String id, final JSONObject content) throws JSONException {
+    return new User(this.kuzzle, id, content, null);
+  }
+
+  /**
+   * {@link #user(String, JSONObject, JSONObject)}
    */
   public User user(@NonNull final String id) throws JSONException {
-    return new User(this.kuzzle, id, null);
+    return new User(this.kuzzle, id, null, null);
   }
 
   /**

--- a/src/main/java/io/kuzzle/sdk/security/User.java
+++ b/src/main/java/io/kuzzle/sdk/security/User.java
@@ -29,10 +29,11 @@ public class User extends AbstractSecurityDocument {
    * @param kuzzle  Kuzzle instance to attach
    * @param id      User unique identifier
    * @param content User content
+   * @param meta User metadata
    * @throws JSONException 
    */
-  public User(final Kuzzle kuzzle, @NonNull final String id, final JSONObject content) throws JSONException {
-    super(kuzzle, id, null);
+  public User(final Kuzzle kuzzle, @NonNull final String id, final JSONObject content, final JSONObject meta) throws JSONException {
+    super(kuzzle, id, null, meta);
     this.deleteActionName = "deleteUser";
     this.updateActionName = "updateUser";
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/whoAmiTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/whoAmiTest.java
@@ -64,7 +64,12 @@ public class whoAmiTest {
             .put("_source", new JSONObject()
               .put("profile", new JSONObject()
                 .put("_id", "admin")
-                .put("roles", "")))));
+                .put("roles", "")
+              )
+            )
+            .put("_meta", new JSONObject())
+          )
+        );
 
         ((OnQueryDoneListener) invocation.getArguments()[3]).onError(mock(JSONObject.class));
         return null;

--- a/src/test/java/io/kuzzle/test/security/KuzzleProfileTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleProfileTest.java
@@ -34,12 +34,12 @@ public class KuzzleProfileTest {
   public void setUp() throws JSONException {
     kuzzle = mock(Kuzzle.class);
     kuzzle.security = new Security(kuzzle);
-    stubProfile = new Profile(kuzzle, "foo", null);
+    stubProfile = new Profile(kuzzle, "foo", null, null);
   }
 
   @Test
   public void testConstructorNoContent() throws JSONException {
-    Profile profile = new Profile(kuzzle, "foo", null);
+    Profile profile = new Profile(kuzzle, "foo", null, null);
     assertEquals(profile.id, "foo");
     assertEquals(profile.getPolicies().length, 0);
     assertThat(profile.content, instanceOf(JSONObject.class));
@@ -53,7 +53,7 @@ public class KuzzleProfileTest {
         "\"policies\": [{\"roleId\": \"foo\"}, {\"roleId\": \"bar\"}, {\"roleId\": \"baz\"}]" +
       "}"
     );
-    Profile profile = new Profile(kuzzle, "foo", content);
+    Profile profile = new Profile(kuzzle, "foo", content, null);
     assertEquals(profile.id, "foo");
     assertEquals(profile.getPolicies().length, 3);
     assertEquals(profile.getPolicies()[2].getString("roleId"), "baz");
@@ -72,12 +72,25 @@ public class KuzzleProfileTest {
         "]" +
       "}"
     );
-    Profile profile = new Profile(kuzzle, "foo", content);
+    Profile profile = new Profile(kuzzle, "foo", content, null);
     assertEquals(profile.id, "foo");
     assertEquals(profile.getPolicies().length, 3);
     assertEquals(profile.getPolicies()[2].getString("roleId"), "baz");
     assertThat(profile.content, instanceOf(JSONObject.class));
     assertEquals(profile.content.length(), 0);
+  }
+
+  @Test
+  public void testConstructorMeta() throws JSONException {
+    JSONObject meta = new JSONObject()
+      .put("createdAt", "0123456789")
+      .put("author", "-1");
+    Profile profile = new Profile(kuzzle, "foo", null, meta);
+    assertEquals(profile.id, "foo");
+    assertEquals(profile.getMeta().length(), 2);
+    assertEquals(profile.getMeta().getString("createdAt"), "0123456789");
+    assertEquals(profile.getMeta().getString("author"), "-1");
+    assertThat(profile.meta, instanceOf(JSONObject.class));
   }
 
   @Test

--- a/src/test/java/io/kuzzle/test/security/KuzzleRoleTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleRoleTest.java
@@ -15,7 +15,9 @@ import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.security.Role;
 import io.kuzzle.sdk.security.Security;
 
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -30,7 +32,20 @@ public class KuzzleRoleTest {
   public void setUp() throws JSONException {
     kuzzle = mock(Kuzzle.class);
     kuzzle.security = new Security(kuzzle);
-    stubRole = new Role(kuzzle, "foo", null);
+    stubRole = new Role(kuzzle, "foo", null, null);
+  }
+
+  @Test
+  public void testConstructorMeta() throws JSONException {
+    JSONObject meta = new JSONObject()
+      .put("createdAt", "0123456789")
+      .put("author", "-1");
+    Role role = new Role(kuzzle, "foo", null, meta);
+    assertEquals(role.id, "foo");
+    assertEquals(role.getMeta().length(), 2);
+    assertEquals(role.getMeta().getString("createdAt"), "0123456789");
+    assertEquals(role.getMeta().getString("author"), "-1");
+    assertThat(role.meta, instanceOf(JSONObject.class));
   }
 
   @Test

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/AbstractKuzzleSecurityDocumentTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/AbstractKuzzleSecurityDocumentTest.java
@@ -37,7 +37,7 @@ public class AbstractKuzzleSecurityDocumentTest {
     kuzzle = mock(Kuzzle.class);
     kuzzle.security = new Security(kuzzle);
     listener = mock(ResponseListener.class);
-    stubRole = new Role(kuzzle, "foo", new JSONObject("{\"foo\":\"bar\"}"));
+    stubRole = new Role(kuzzle, "foo", new JSONObject("{\"foo\":\"bar\"}"), null);
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/createProfileTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/createProfileTest.java
@@ -73,12 +73,13 @@ public class createProfileTest {
         JSONObject response = new JSONObject(
           "{" +
             "\"result\": {" +
-            "\"_id\": \"foobar\"," +
-            "\"_source\": {" +
-            "\"indexes\": {}" +
+              "\"_id\": \"foobar\"," +
+              "\"_source\": {" +
+                "\"indexes\": {}" +
+              "}," +
+              "\"_meta\": {}" +
             "}" +
-            "}" +
-            "}");
+          "}");
 
         ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(response);
         ((OnQueryDoneListener) invocation.getArguments()[3]).onError(new JSONObject().put("error", "stub"));

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/createRestrictedUserTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/createRestrictedUserTest.java
@@ -78,12 +78,13 @@ public class createRestrictedUserTest {
         JSONObject response = new JSONObject(
           "{" +
             "\"result\": {" +
-            "\"_id\": \"foobar\"," +
-            "\"_source\": {" +
-            "\"indexes\": {}" +
+              "\"_id\": \"foobar\"," +
+              "\"_source\": {" +
+                "\"indexes\": {}" +
+              "}," +
+              "\"_meta\": {}" +
             "}" +
-            "}" +
-            "}");
+          "}");
 
         ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(response);
         ((OnQueryDoneListener) invocation.getArguments()[3]).onError(new JSONObject().put("error", "stub"));

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/createRoleTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/createRoleTest.java
@@ -72,12 +72,13 @@ public class createRoleTest {
         JSONObject response = new JSONObject(
           "{" +
             "\"result\": {" +
-            "\"_id\": \"foobar\"," +
-            "\"_source\": {" +
-            "\"indexes\": {}" +
+              "\"_id\": \"foobar\"," +
+              "\"_source\": {" +
+                "\"indexes\": {}" +
+              "}," +
+              "\"_meta\": {}" +
             "}" +
-            "}" +
-            "}");
+          "}");
 
         ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(response);
         ((OnQueryDoneListener) invocation.getArguments()[3]).onError(new JSONObject().put("error", "stub"));

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/createUserTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/createUserTest.java
@@ -61,12 +61,13 @@ public class createUserTest {
         JSONObject response = new JSONObject(
           "{" +
             "\"result\": {" +
-            "\"_id\": \"foobar\"," +
-            "\"_source\": {" +
-            "\"indexes\": {}" +
+              "\"_id\": \"foobar\"," +
+              "\"_source\": {" +
+                "\"indexes\": {}" +
+              "}," +
+              "\"_meta\": {}" +
             "}" +
-            "}" +
-            "}");
+          "}");
 
         ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(response);
         ((OnQueryDoneListener) invocation.getArguments()[3]).onError(new JSONObject().put("error", "stub"));

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/getProfileTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/getProfileTest.java
@@ -39,7 +39,7 @@ public class getProfileTest {
   }
 
   @Test(expected = RuntimeException.class)
-  public void testgetProfileBadResponse() throws JSONException {
+  public void testGetProfileBadResponse() throws JSONException {
     doAnswer(new Answer() {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {
@@ -55,11 +55,11 @@ public class getProfileTest {
   }
 
   @Test
-  public void testgetProfileGoodFullResponse() throws JSONException {
+  public void testGetProfileGoodFullResponse() throws JSONException {
     doAnswer(new Answer() {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {
-        JSONObject response = new JSONObject("{\"result\":{\"_id\":\"foobar\",\"_source\":{\"policies\":[{\"roleId\":\"baz\",\"restrictedTo\":[{\"index\":\"qux\"}],\"allowInternalIndex\":true}]}}}");
+        JSONObject response = new JSONObject("{\"result\":{\"_id\":\"foobar\",\"_source\":{\"policies\":[{\"roleId\":\"baz\",\"restrictedTo\":[{\"index\":\"qux\"}],\"allowInternalIndex\":true}]},\"_meta\":{}}}");
 
         ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(response);
         ((OnQueryDoneListener) invocation.getArguments()[3]).onError(new JSONObject().put("error", "stub"));
@@ -72,11 +72,11 @@ public class getProfileTest {
   }
 
   @Test
-  public void testgetProfileGoodMinimalResponse() throws JSONException {
+  public void testGetProfileGoodMinimalResponse() throws JSONException {
     doAnswer(new Answer() {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {
-        JSONObject response = new JSONObject("{\"result\":{\"_id\":\"foobar\",\"_source\":{\"policies\":[{\"roleId\":\"baz\"}]}}}");
+        JSONObject response = new JSONObject("{\"result\":{\"_id\":\"foobar\",\"_source\":{\"policies\":[{\"roleId\":\"baz\"}]},\"_meta\":{}}}");
 
         ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(response);
         ((OnQueryDoneListener) invocation.getArguments()[3]).onError(new JSONObject().put("error", "stub"));
@@ -89,11 +89,11 @@ public class getProfileTest {
   }
 
   @Test
-  public void testgetProfileGoodWithRestrictedToResponse() throws JSONException {
+  public void testGetProfileGoodWithRestrictedToResponse() throws JSONException {
     doAnswer(new Answer() {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {
-        JSONObject response = new JSONObject("{\"result\":{\"_id\":\"foobar\",\"_source\":{\"policies\":[{\"roleId\":\"baz\"}],\"restrictedTo\":[{\"index\":\"qux\"}]}}}");
+        JSONObject response = new JSONObject("{\"result\":{\"_id\":\"foobar\",\"_source\":{\"policies\":[{\"roleId\":\"baz\"}],\"restrictedTo\":[{\"index\":\"qux\"}]},\"_meta\":{}}}");
 
         ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(response);
         ((OnQueryDoneListener) invocation.getArguments()[3]).onError(new JSONObject().put("error", "stub"));
@@ -106,11 +106,11 @@ public class getProfileTest {
   }
 
   @Test
-  public void testgetProfileGoodWithAllowInternalIndexResponse() throws JSONException {
+  public void testGetProfileGoodWithAllowInternalIndexResponse() throws JSONException {
     doAnswer(new Answer() {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {
-        JSONObject response = new JSONObject("{\"result\":{\"_id\":\"foobar\",\"_source\":{\"policies\":[{\"roleId\":\"baz\"}],\"allowInternalIndex\":true}}}");
+        JSONObject response = new JSONObject("{\"result\":{\"_id\":\"foobar\",\"_source\":{\"policies\":[{\"roleId\":\"baz\"}],\"allowInternalIndex\":true},\"_meta\":{}}}");
 
         ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(response);
         ((OnQueryDoneListener) invocation.getArguments()[3]).onError(new JSONObject().put("error", "stub"));

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/getRoleTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/getRoleTest.java
@@ -53,12 +53,13 @@ public class getRoleTest {
         JSONObject response = new JSONObject(
           "{" +
             "\"result\": {" +
-            "\"_id\": \"foobar\"," +
-            "\"_source\": {" +
-            "\"indexes\": {}" +
+              "\"_id\": \"foobar\"," +
+              "\"_source\": {" +
+                "\"indexes\": {}" +
+              "}," +
+              "\"_meta\": {}" +
             "}" +
-            "}" +
-            "}");
+          "}");
 
         ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(response);
         ((OnQueryDoneListener) invocation.getArguments()[3]).onError(new JSONObject().put("error", "stub"));
@@ -86,7 +87,7 @@ public class getRoleTest {
     ArgumentCaptor argument = ArgumentCaptor.forClass(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class);
     verify(kuzzle, times(1)).query((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.capture(), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));
     assertEquals(((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.getValue()).controller, "security");
-    assertEquals(((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.getValue()).action, "fetchRole");
+    assertEquals(((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.getValue()).action, "getRole");
   }
 
   @Test(expected = RuntimeException.class)

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/getUserTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/getUserTest.java
@@ -45,17 +45,18 @@ public class getUserTest {
   }
 
   @Test
-  public void testgetUserValidResponse() throws JSONException {
+  public void testGetUserValidResponse() throws JSONException {
     doAnswer(new Answer() {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {
         JSONObject response = new JSONObject(
           "{" +
             "\"result\": {" +
-            "\"_id\": \"foobar\"," +
-            "\"_source\": {}" +
+              "\"_id\": \"foobar\"," +
+              "\"_source\": {}," +
+              "\"_meta\": {}" +
             "}" +
-            "}");
+          "}");
 
         ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(response);
         ((OnQueryDoneListener) invocation.getArguments()[3]).onError(new JSONObject().put("error", "stub"));
@@ -82,11 +83,11 @@ public class getUserTest {
     ArgumentCaptor argument = ArgumentCaptor.forClass(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class);
     verify(kuzzle, times(1)).query((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.capture(), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));
     assertEquals(((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.getValue()).controller, "security");
-    assertEquals(((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.getValue()).action, "fetchUser");
+    assertEquals(((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.getValue()).action, "getUser");
   }
 
   @Test(expected = RuntimeException.class)
-  public void testgetUserBadResponse() throws JSONException {
+  public void testGetUserBadResponse() throws JSONException {
     doAnswer(new Answer() {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/replaceUserTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/replaceUserTest.java
@@ -55,7 +55,8 @@ public class replaceUserTest {
                 "{" +
                     "\"result\": {" +
                     "\"_id\": \"foo\"," +
-                    "\"_source\": {}" +
+                    "\"_source\": {}," +
+                    "\"_meta\": {}" +
                     "}" +
                 "}");
 

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/scrollProfilesTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/scrollProfilesTest.java
@@ -128,6 +128,7 @@ public class scrollProfilesTest {
                 "          \"status\": \"idle\",\n" +
                 "          \"type\": \"customer\"\n" +
                 "        },\n" +
+                "        \"_meta\": {},\n" +
                 "        \"_type\": \"users\"\n" +
                 "      },\n" +
                 "      {\n" +
@@ -143,6 +144,7 @@ public class scrollProfilesTest {
                 "          \"status\": \"idle\",\n" +
                 "          \"type\": \"cab\"\n" +
                 "        },\n" +
+                "        \"_meta\": {},\n" +
                 "        \"_type\": \"users\"\n" +
                 "      }\n" +
                 "    ],\n" +

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/scrollUsersTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/scrollUsersTest.java
@@ -128,6 +128,7 @@ public class scrollUsersTest {
                 "          \"status\": \"idle\",\n" +
                 "          \"type\": \"customer\"\n" +
                 "        },\n" +
+                "        \"_meta\": {},\n" +
                 "        \"_type\": \"users\"\n" +
                 "      },\n" +
                 "      {\n" +
@@ -143,6 +144,7 @@ public class scrollUsersTest {
                 "          \"status\": \"idle\",\n" +
                 "          \"type\": \"cab\"\n" +
                 "        },\n" +
+                "        \"_meta\": {},\n" +
                 "        \"_type\": \"users\"\n" +
                 "      }\n" +
                 "    ],\n" +

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/searchProfilesTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/searchProfilesTest.java
@@ -52,18 +52,19 @@ public class searchProfilesTest {
         JSONObject response = new JSONObject(
           "{" +
             "\"result\": {" +
-            "\"hits\": [" +
-            "{" +
-            "\"_id\": \"foobar\"," +
-            "\"_source\": {" +
-            "\"_id\": \"foobar\"," +
-            "\"indexes\": {}" +
+              "\"hits\": [" +
+                "{" +
+                  "\"_id\": \"foobar\"," +
+                  "\"_source\": {" +
+                    "\"_id\": \"foobar\"," +
+                    "\"indexes\": {}" +
+                  "}," +
+                  "\"_meta\": {}" +
+                "}" +
+              "]," +
+              "\"total\": 1" +
             "}" +
-            "}" +
-            "]," +
-            "\"total\": 1" +
-            "}" +
-            "}");
+          "}");
 
         ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(response);
         ((OnQueryDoneListener) invocation.getArguments()[3]).onError(new JSONObject().put("error", "stub"));

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/searchRolesTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/searchRolesTest.java
@@ -52,18 +52,19 @@ public class searchRolesTest {
         JSONObject response = new JSONObject(
           "{" +
             "\"result\": {" +
-            "\"hits\": [" +
-            "{" +
-            "\"_id\": \"foobar\"," +
-            "\"_source\": {" +
-            "\"_id\": \"foobar\"," +
-            "\"indexes\": {}" +
+              "\"hits\": [" +
+                "{" +
+                  "\"_id\": \"foobar\"," +
+                  "\"_source\": {" +
+                    "\"_id\": \"foobar\"," +
+                    "\"indexes\": {}" +
+                  "}," +
+                  "\"_meta\": {}" +
+                "}" +
+              "]," +
+              "\"total\": 1" +
             "}" +
-            "}" +
-            "]," +
-            "\"total\": 1" +
-            "}" +
-            "}");
+          "}");
 
         ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(response);
         ((OnQueryDoneListener) invocation.getArguments()[3]).onError(new JSONObject().put("error", "stub"));

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/searchUsersTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/searchUsersTest.java
@@ -52,18 +52,19 @@ public class searchUsersTest {
         JSONObject response = new JSONObject(
           "{" +
             "\"result\": {" +
-            "\"hits\": [" +
-            "{" +
-            "\"_id\": \"foobar\"," +
-            "\"_source\": {" +
-            "\"_id\": \"foobar\"," +
-            "\"indexes\": {}" +
+              "\"hits\": [" +
+                "{" +
+                  "\"_id\": \"foobar\"," +
+                  "\"_source\": {" +
+                    "\"_id\": \"foobar\"," +
+                    "\"indexes\": {}" +
+                  "}," +
+                  "\"_meta\": {}" +
+                "}" +
+              "]," +
+              "\"total\": 1" +
             "}" +
-            "}" +
-            "]," +
-            "\"total\": 1" +
-            "}" +
-            "}");
+          "}");
 
         ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(response);
         ((OnQueryDoneListener) invocation.getArguments()[3]).onError(new JSONObject().put("error", "stub"));

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/updateProfileTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/updateProfileTest.java
@@ -53,10 +53,11 @@ public class updateProfileTest {
         JSONObject response = new JSONObject(
           "{" +
             "\"result\": {" +
-            "\"_id\": \"foobar\"," +
-              "\"_source\": {}" +
+              "\"_id\": \"foobar\"," +
+              "\"_source\": {}," +
+              "\"_meta\": {}" +
             "}" +
-            "}");
+          "}");
 
         ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(response);
         ((OnQueryDoneListener) invocation.getArguments()[3]).onError(new JSONObject().put("error", "stub"));

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/updateRoleTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/updateRoleTest.java
@@ -52,12 +52,13 @@ public class updateRoleTest {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {
         JSONObject response = new JSONObject(
-            "{" +
-                "\"result\": {" +
-                "\"_id\": \"foobar\"," +
-                "\"_source\": {}" +
-                "}" +
-                "}");
+          "{" +
+            "\"result\": {" +
+              "\"_id\": \"foobar\"," +
+              "\"_source\": {}," +
+              "\"_meta\": {}" +
+            "}" +
+          "}");
 
         ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(response);
         ((OnQueryDoneListener) invocation.getArguments()[3]).onError(new JSONObject().put("error", "stub"));

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/updateUserTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/updateUserTest.java
@@ -52,12 +52,13 @@ public class updateUserTest {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {
         JSONObject response = new JSONObject(
-            "{" +
-                "\"result\": {" +
-                "\"_id\": \"foobar\"," +
-                "\"_source\": {}" +
-                "}" +
-                "}");
+          "{" +
+            "\"result\": {" +
+              "\"_id\": \"foobar\"," +
+              "\"_source\": {}," +
+              "\"_meta\": {}" +
+            "}" +
+          "}");
 
         ((OnQueryDoneListener) invocation.getArguments()[3]).onSuccess(response);
         ((OnQueryDoneListener) invocation.getArguments()[3]).onError(new JSONObject().put("error", "stub"));


### PR DESCRIPTION
## Introduces
- Meta in Security documents (User, Profile, Role)

## Boyscoot
- Updated get Security document API endpoint (`fetchUser|Profile|Role` -> `getUser|Profile|Role`)

**Should only be merged after Kuzzle side PR**
https://github.com/kuzzleio/kuzzle/pull/897