### PR TITLE
Fixed various subscribe issues

### DIFF
--- a/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
+++ b/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
@@ -1303,7 +1303,7 @@ public class Kuzzle {
 
   /**
    * Renew all registered subscriptions. Usually called after:
-   * - a connection, if subscriptions occured before
+   * - a connection, if subscriptions occurred before
    * - a reconnection
    * - after a successful login attempt, to subscribe with the new credentials
    */
@@ -1430,7 +1430,7 @@ public class Kuzzle {
    */
   protected Socket createSocket() throws URISyntaxException {
     IO.Options opt = new IO.Options();
-    opt.forceNew = true;
+    opt.forceNew = false;
     opt.reconnection = this.autoReconnect;
     opt.reconnectionDelay = this.reconnectionDelay;
     return IO.socket("http://" + host + ":" + this.port, opt);

--- a/src/main/java/io/kuzzle/sdk/enums/Scope.java
+++ b/src/main/java/io/kuzzle/sdk/enums/Scope.java
@@ -4,5 +4,6 @@ public enum Scope {
   IN,
   OUT,
   ALL,
-  NONE
+  NONE,
+  UNKNOWN
 }

--- a/src/main/java/io/kuzzle/sdk/enums/Users.java
+++ b/src/main/java/io/kuzzle/sdk/enums/Users.java
@@ -1,8 +1,5 @@
 package io.kuzzle.sdk.enums;
 
-/**
- * Created by kblondel on 11/12/15.
- */
 public enum Users {
   IN,
   OUT,

--- a/src/main/java/io/kuzzle/sdk/responses/NotificationResponse.java
+++ b/src/main/java/io/kuzzle/sdk/responses/NotificationResponse.java
@@ -44,8 +44,12 @@ public class NotificationResponse {
       this.scope = (object.isNull("scope") ? null : Scope.valueOf(object.getString("scope").toUpperCase()));
       this.users = (object.isNull("user") ? null : Users.valueOf(object.getString("user").toUpperCase()));
       if (!object.getJSONObject("result").isNull("_source")) {
-        this.document = new Document(new Collection(kuzzle, this.collection, this.index), object.getJSONObject("result"));
-        this.document.setId(this.result.getString("_id"));
+        JSONObject content = object.getJSONObject("result");
+        String id = content.getString("_id");
+        JSONObject meta = content.isNull("_meta") ? new JSONObject() : content.getJSONObject("_meta");
+        content.remove("_id");
+        content.remove("_meta");
+        this.document = new Document(new Collection(kuzzle, this.collection, this.index), id, content, meta);
       }
     } catch (JSONException e) {
       throw new RuntimeException(e);

--- a/src/test/java/io/kuzzle/test/testUtils/RoomExtend.java
+++ b/src/test/java/io/kuzzle/test/testUtils/RoomExtend.java
@@ -10,9 +10,6 @@ import io.kuzzle.sdk.core.Room;
 import io.kuzzle.sdk.core.RoomOptions;
 import io.kuzzle.sdk.listeners.ResponseListener;
 
-/**
- * Created by scottinet on 19/02/16.
- */
 public class RoomExtend extends Room {
 
   public RoomExtend(Collection kuzzleDataCollection) {


### PR DESCRIPTION
- Fixed the multiple subscription issue (when subscribing multiple times with the same filters, Socket.io wouldn't use the already existing connexion and created a new one, the proxy would then consider that the subscription was made by anoter client)
- Crash when receiving a Notification with "unknown" scope (delete queries), missing value in ENUM
- Fixed missing _meta in Document entity created upon receiving a Document Notification (create, replace etc.)