### PR TITLE
simplify use of response listeners

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,10 @@ dependencies {
     testCompile 'org.hamcrest:hamcrest-junit:2.0.0.0'
     testCompile 'org.mockito:mockito-core:1.9.5'
     testCompile 'org.skyscreamer:jsonassert:1.5.0'
+    // allows mocking static methods
+    testCompile 'org.powermock:powermock:1.6.6'
+    testCompile 'org.powermock:powermock-module-junit4:1.6.6'
+    testCompile 'org.powermock:powermock-api-mockito:1.6.6'
     // for not mocking JSONObject
     testCompile files('libs-test/json-20140107.jar')
     androidTestCompile 'junit:junit:4.12'

--- a/src/main/java/io/kuzzle/sdk/listeners/OnQueryDoneListener.java
+++ b/src/main/java/io/kuzzle/sdk/listeners/OnQueryDoneListener.java
@@ -8,9 +8,7 @@ public abstract class OnQueryDoneListener {
   public abstract void onSuccess(JSONObject response);
   public void onError(JSONObject error) {
     if (error != null) {
-      Log.e(ResponseListener.TAG_API_ERROR, "Default error handler invoked: " + error.toString());
-    } else {
-      Log.e(ResponseListener.TAG_API_ERROR, Arrays.toString(Thread.currentThread().getStackTrace()));
-    }
+      Log.e(ResponseListener.LOG_TAG, "Default error handler invoked: " + error.toString());
+    } 
   }
 }

--- a/src/main/java/io/kuzzle/sdk/listeners/OnQueryDoneListener.java
+++ b/src/main/java/io/kuzzle/sdk/listeners/OnQueryDoneListener.java
@@ -2,7 +2,13 @@ package io.kuzzle.sdk.listeners;
 
 import org.json.JSONObject;
 
-public interface OnQueryDoneListener {
-  void onSuccess(JSONObject response);
-  void onError(JSONObject error);
+public abstract class OnQueryDoneListener {
+  public abstract void onSuccess(JSONObject response);
+  public void onError(JSONObject error) {
+    if (error != null) {
+      System.err.println("Default error handler invoked: " + error.toString());
+    } else {
+      new Throwable().printStackTrace(System.err);
+    }
+  }
 }

--- a/src/main/java/io/kuzzle/sdk/listeners/OnQueryDoneListener.java
+++ b/src/main/java/io/kuzzle/sdk/listeners/OnQueryDoneListener.java
@@ -1,14 +1,16 @@
 package io.kuzzle.sdk.listeners;
 
 import org.json.JSONObject;
+import android.util.Log;
+import java.util.Arrays;
 
 public abstract class OnQueryDoneListener {
   public abstract void onSuccess(JSONObject response);
   public void onError(JSONObject error) {
     if (error != null) {
-      System.err.println("Default error handler invoked: " + error.toString());
+      Log.e(ResponseListener.TAG_API_ERROR, "Default error handler invoked: " + error.toString());
     } else {
-      new Throwable().printStackTrace(System.err);
+      Log.e(ResponseListener.TAG_API_ERROR, Arrays.toString(Thread.currentThread().getStackTrace()));
     }
   }
 }

--- a/src/main/java/io/kuzzle/sdk/listeners/ResponseListener.java
+++ b/src/main/java/io/kuzzle/sdk/listeners/ResponseListener.java
@@ -1,11 +1,15 @@
 package io.kuzzle.sdk.listeners;
 
 import org.json.JSONObject;
+import android.util.Log;
+import java.util.Arrays;
 
 /**
  * The interface Response listener.
  */
 public abstract class ResponseListener<T> {
+  public static final String TAG_API_ERROR = "Kuzzle SDK Error";
+
   /**
    * On success.
    *
@@ -20,9 +24,9 @@ public abstract class ResponseListener<T> {
    */
   public void onError(JSONObject error) {
     if (error != null) {
-      System.err.println("Default error handler invoked: " + error.toString());
+      Log.e(TAG_API_ERROR, "Default error handler invoked: " + error.toString());
     } else {
-      new Throwable().printStackTrace(System.err);
+      Log.e(TAG_API_ERROR, Arrays.toString(Thread.currentThread().getStackTrace()));
     }
   }
 }

--- a/src/main/java/io/kuzzle/sdk/listeners/ResponseListener.java
+++ b/src/main/java/io/kuzzle/sdk/listeners/ResponseListener.java
@@ -5,18 +5,24 @@ import org.json.JSONObject;
 /**
  * The interface Response listener.
  */
-public interface ResponseListener<T> {
+public abstract class ResponseListener<T> {
   /**
    * On success.
    *
    * @param response Raw Kuzzle API response
    */
-  void onSuccess(T response);
+  public abstract void onSuccess(T response);
 
   /**
    * On error.
    *
    * @param error Raw Kuzzle API error content
    */
-  void onError(JSONObject error);
+  public void onError(JSONObject error) {
+    if (error != null) {
+      System.err.println("Default error handler invoked: " + error.toString());
+    } else {
+      new Throwable().printStackTrace(System.err);
+    }
+  }
 }

--- a/src/main/java/io/kuzzle/sdk/listeners/ResponseListener.java
+++ b/src/main/java/io/kuzzle/sdk/listeners/ResponseListener.java
@@ -8,7 +8,7 @@ import java.util.Arrays;
  * The interface Response listener.
  */
 public abstract class ResponseListener<T> {
-  public static final String TAG_API_ERROR = "Kuzzle SDK Error";
+  public static final String LOG_TAG = "Kuzzle SDK Error";
 
   /**
    * On success.
@@ -24,9 +24,7 @@ public abstract class ResponseListener<T> {
    */
   public void onError(JSONObject error) {
     if (error != null) {
-      Log.e(TAG_API_ERROR, "Default error handler invoked: " + error.toString());
-    } else {
-      Log.e(TAG_API_ERROR, Arrays.toString(Thread.currentThread().getStackTrace()));
-    }
+      Log.e(LOG_TAG, "Default error handler invoked: " + error.toString());
+    } 
   }
 }

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/checkTokenTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/checkTokenTest.java
@@ -45,11 +45,6 @@ public class checkTokenTest {
       public void onSuccess(Object object) {
 
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     };
   }
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/connectionManagementTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/connectionManagementTest.java
@@ -8,6 +8,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+
 import java.net.URISyntaxException;
 import java.util.Date;
 import java.util.Map;
@@ -43,6 +48,8 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({android.util.Log.class})
 public class connectionManagementTest {
   private KuzzleExtend kuzzle;
   private Socket s;
@@ -50,6 +57,7 @@ public class connectionManagementTest {
 
   @Before
   public void setUp() throws URISyntaxException {
+    PowerMockito.mockStatic(android.util.Log.class);
     Options options = new Options();
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/connectionManagementTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/connectionManagementTest.java
@@ -58,12 +58,6 @@ public class connectionManagementTest {
     listener = new ResponseListener<Object>() {
       @Override
       public void onSuccess(Object object) {
-
-      }
-
-      @Override
-      public void onError(JSONObject error) {
-
       }
     };
     kuzzle = new KuzzleExtend("localhost", options, listener);

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/constructorTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/constructorTest.java
@@ -49,11 +49,6 @@ public class constructorTest {
       public void onSuccess(Object object) {
 
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     };
   }
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/createIndexTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/createIndexTest.java
@@ -39,11 +39,6 @@ public class createIndexTest {
       public void onSuccess(Object object) {
 
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     };
   }
   @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/createMyCredentialsTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/createMyCredentialsTest.java
@@ -48,11 +48,6 @@ public class createMyCredentialsTest {
       public void onSuccess(Object object) {
 
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     };
   }
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/deleteMyCredentialsTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/deleteMyCredentialsTest.java
@@ -38,11 +38,6 @@ public class deleteMyCredentialsTest {
       public void onSuccess(Object object) {
 
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     };
   }
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/eventSystemTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/eventSystemTest.java
@@ -51,11 +51,6 @@ public class eventSystemTest {
       public void onSuccess(Object object) {
 
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     };
   }
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/factoriesTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/factoriesTest.java
@@ -35,11 +35,6 @@ public class factoriesTest {
       public void onSuccess(Object object) {
 
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     };
   }
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/getAllStatisticsTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/getAllStatisticsTest.java
@@ -49,11 +49,6 @@ public class getAllStatisticsTest {
       public void onSuccess(Object object) {
 
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     };
   }
 
@@ -138,11 +133,6 @@ public class getAllStatisticsTest {
         } catch (JSONException e) {
           e.printStackTrace();
         }
-      }
-
-      @Override
-      public void onError(JSONObject error) {
-
       }
     });
     ArgumentCaptor argument = ArgumentCaptor.forClass(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class);

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/getAllStatisticsTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/getAllStatisticsTest.java
@@ -8,6 +8,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+
 import java.net.URISyntaxException;
 import java.util.Iterator;
 
@@ -30,12 +35,15 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({android.util.Log.class})
 public class getAllStatisticsTest {
   private KuzzleExtend kuzzle;
   private ResponseListener listener;
 
   @Before
   public void setUp() throws URISyntaxException {
+    PowerMockito.mockStatic(android.util.Log.class);
     Options options = new Options();
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/getLastStatisticsTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/getLastStatisticsTest.java
@@ -44,11 +44,6 @@ public class getLastStatisticsTest {
       public void onSuccess(Object object) {
 
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     };
   }
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/getMyCredentialsTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/getMyCredentialsTest.java
@@ -38,11 +38,6 @@ public class getMyCredentialsTest {
       public void onSuccess(Object object) {
 
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     };
   }
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/getServerInfoTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/getServerInfoTest.java
@@ -44,11 +44,6 @@ public class getServerInfoTest {
       public void onSuccess(Object object) {
 
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     };
   }
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/getServerInfoTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/getServerInfoTest.java
@@ -8,6 +8,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+
 import java.net.URISyntaxException;
 
 import io.kuzzle.sdk.core.Options;
@@ -26,12 +31,15 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({android.util.Log.class})
 public class getServerInfoTest {
   private KuzzleExtend kuzzle;
   private ResponseListener listener;
 
   @Before
   public void setUp() throws URISyntaxException {
+    PowerMockito.mockStatic(android.util.Log.class);
     Options options = new Options();
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/getStatisticsTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/getStatisticsTest.java
@@ -44,11 +44,6 @@ public class getStatisticsTest {
       public void onSuccess(Object object) {
 
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     };
   }
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/getStatisticsTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/getStatisticsTest.java
@@ -9,6 +9,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+
 import java.net.URISyntaxException;
 
 import io.kuzzle.sdk.core.Options;
@@ -26,12 +31,15 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({android.util.Log.class})
 public class getStatisticsTest {
   private KuzzleExtend kuzzle;
   private ResponseListener listener;
 
   @Before
   public void setUp() throws URISyntaxException {
+    PowerMockito.mockStatic(android.util.Log.class);
     Options options = new Options();
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/kuzzleWebViewTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/kuzzleWebViewTest.java
@@ -41,11 +41,6 @@ public class kuzzleWebViewTest {
       public void onSuccess(Object object) {
 
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     };
   }
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/listCollectionsTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/listCollectionsTest.java
@@ -9,6 +9,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+
 import java.net.URISyntaxException;
 
 import io.kuzzle.sdk.core.Options;
@@ -27,12 +32,15 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({android.util.Log.class})
 public class listCollectionsTest {
   private KuzzleExtend kuzzle;
   private ResponseListener listener;
 
   @Before
   public void setUp() throws URISyntaxException {
+    PowerMockito.mockStatic(android.util.Log.class);
     Options options = new Options();
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/listCollectionsTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/listCollectionsTest.java
@@ -45,11 +45,6 @@ public class listCollectionsTest {
       public void onSuccess(Object object) {
 
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     };
   }
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/listIndexesTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/listIndexesTest.java
@@ -45,11 +45,6 @@ public class listIndexesTest {
       public void onSuccess(Object object) {
 
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     };
   }
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/listIndexesTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/listIndexesTest.java
@@ -9,6 +9,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+
 import java.net.URISyntaxException;
 
 import io.kuzzle.sdk.core.Options;
@@ -27,12 +32,15 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({android.util.Log.class})
 public class listIndexesTest {
   private KuzzleExtend kuzzle;
   private ResponseListener listener;
 
   @Before
   public void setUp() throws URISyntaxException {
+    PowerMockito.mockStatic(android.util.Log.class);
     Options options = new Options();
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/loginTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/loginTest.java
@@ -8,6 +8,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+
 import java.net.URISyntaxException;
 
 import io.kuzzle.sdk.core.Kuzzle;
@@ -29,6 +34,8 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({android.util.Log.class})
 public class loginTest {
   private KuzzleExtend kuzzle;
   private Socket s;
@@ -36,6 +43,7 @@ public class loginTest {
 
   @Before
   public void setUp() throws URISyntaxException {
+    PowerMockito.mockStatic(android.util.Log.class);
     Options options = new Options();
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/loginTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/loginTest.java
@@ -49,11 +49,6 @@ public class loginTest {
       public void onSuccess(Object object) {
 
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     };
   }
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/logoutTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/logoutTest.java
@@ -47,11 +47,6 @@ public class logoutTest {
       public void onSuccess(Object object) {
 
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     };
   }
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/nowTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/nowTest.java
@@ -46,11 +46,6 @@ public class nowTest {
       public void onSuccess(Object object) {
 
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     };
   }
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/nowTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/nowTest.java
@@ -8,6 +8,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+
 import java.net.URISyntaxException;
 
 import io.kuzzle.sdk.core.Options;
@@ -26,6 +31,8 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({android.util.Log.class})
 public class nowTest {
   private KuzzleExtend kuzzle;
   private Socket s;
@@ -33,6 +40,7 @@ public class nowTest {
 
   @Before
   public void setUp() throws URISyntaxException {
+    PowerMockito.mockStatic(android.util.Log.class);
     Options options = new Options();
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/queryTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/queryTest.java
@@ -304,11 +304,6 @@ public class queryTest {
       public void onSuccess(JSONObject response) {
 
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     });
     doThrow(JSONException.class).when(listener).onSuccess(any(JSONObject.class));
     kuzzle.emitRequest(new JSONObject().put("requestId", "foo"), listener);

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/queueManagementTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/queueManagementTest.java
@@ -50,11 +50,6 @@ public class queueManagementTest {
       public void onSuccess(Object object) {
 
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     };
   }
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/subscriptionsManagementTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/subscriptionsManagementTest.java
@@ -38,11 +38,6 @@ public class subscriptionsManagementTest {
       public void onSuccess(Object object) {
 
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     };
   }
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/updateMyCredentialsTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/updateMyCredentialsTest.java
@@ -46,11 +46,6 @@ public class updateMyCredentialsTest {
       public void onSuccess(Object object) {
 
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     };
   }
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/updateSelfTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/updateSelfTest.java
@@ -39,11 +39,6 @@ public class updateSelfTest {
       public void onSuccess(JSONObject response) {
 
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     });
   }
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/updateSelfTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/updateSelfTest.java
@@ -8,6 +8,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+
 import java.net.URISyntaxException;
 
 import io.kuzzle.sdk.core.Kuzzle;
@@ -24,6 +29,8 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({android.util.Log.class})
 public class updateSelfTest {
 
   Kuzzle kuzzle;
@@ -32,6 +39,7 @@ public class updateSelfTest {
 
   @Before
   public void setUp() throws URISyntaxException {
+    PowerMockito.mockStatic(android.util.Log.class);
     kuzzle = spy(new Kuzzle("localhost"));
     argument = ArgumentCaptor.forClass(Kuzzle.QueryArgs.class);
     listener = spy(new ResponseListener<JSONObject>() {

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/validateMyCredentialsTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/validateMyCredentialsTest.java
@@ -46,11 +46,6 @@ public class validateMyCredentialsTest {
       public void onSuccess(Object object) {
 
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     };
   }
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/whoAmiTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/whoAmiTest.java
@@ -44,11 +44,6 @@ public class whoAmiTest {
       public void onSuccess(Object object) {
 
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     };
   }
 

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/scrollSpecificationsTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/scrollSpecificationsTest.java
@@ -8,6 +8,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+
 import java.net.URISyntaxException;
 
 import io.kuzzle.sdk.core.Collection;
@@ -31,6 +36,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({android.util.Log.class})
 public class scrollSpecificationsTest {
     private Kuzzle kuzzle;
     private Collection collection;
@@ -40,6 +47,7 @@ public class scrollSpecificationsTest {
 
     @Before
     public void setUp() throws URISyntaxException {
+        PowerMockito.mockStatic(android.util.Log.class);
         Options opts = new Options();
         opts.setConnect(Mode.MANUAL);
         opts.setScroll("30s");

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/scrollSpecificationsTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/scrollSpecificationsTest.java
@@ -153,10 +153,6 @@ public class scrollSpecificationsTest {
                     throw new RuntimeException(e);
                 }
             }
-
-            @Override
-            public void onError(JSONObject error) {
-            }
         });
         collection.scrollSpecifications(scrollId, mock(ResponseListener.class));
         ArgumentCaptor argument = ArgumentCaptor.forClass(Kuzzle.QueryArgs.class);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/scrollTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/scrollTest.java
@@ -8,6 +8,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+
 import java.net.URISyntaxException;
 
 import io.kuzzle.sdk.core.Collection;
@@ -32,6 +37,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({android.util.Log.class})
 public class scrollTest {
   private Kuzzle kuzzle;
   private Collection collection;
@@ -42,6 +49,7 @@ public class scrollTest {
 
   @Before
   public void setUp() throws URISyntaxException {
+    PowerMockito.mockStatic(android.util.Log.class);
     Options opts = new Options();
     opts.setConnect(Mode.MANUAL);
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/scrollTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/scrollTest.java
@@ -163,10 +163,6 @@ public class scrollTest {
           throw new RuntimeException(e);
         }
       }
-
-      @Override
-      public void onError(JSONObject error) {
-      }
     });
     collection.scroll(scrollId, mock(ResponseListener.class));
     ArgumentCaptor argument = ArgumentCaptor.forClass(Kuzzle.QueryArgs.class);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/searchSpecificationsTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/searchSpecificationsTest.java
@@ -154,10 +154,6 @@ public class searchSpecificationsTest {
                     throw new RuntimeException(e);
                 }
             }
-
-            @Override
-            public void onError(JSONObject error) {
-            }
         });
         collection.searchSpecifications(filters, mock(ResponseListener.class));
         ArgumentCaptor argument = ArgumentCaptor.forClass(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/searchSpecificationsTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/searchSpecificationsTest.java
@@ -8,6 +8,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+
 import java.net.URISyntaxException;
 
 import io.kuzzle.sdk.core.Kuzzle;
@@ -32,6 +37,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({android.util.Log.class})
 public class searchSpecificationsTest {
     private Kuzzle kuzzle;
     private Collection collection;
@@ -39,6 +46,7 @@ public class searchSpecificationsTest {
 
     @Before
     public void setUp() throws URISyntaxException {
+        PowerMockito.mockStatic(android.util.Log.class);
         Options opts = new Options();
         opts.setConnect(Mode.MANUAL);
         KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/searchTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/searchTest.java
@@ -155,10 +155,6 @@ public class searchTest {
           throw new RuntimeException(e);
         }
       }
-
-      @Override
-      public void onError(JSONObject error) {
-      }
     });
     collection.search(filters, mock(ResponseListener.class));
     ArgumentCaptor argument = ArgumentCaptor.forClass(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class);
@@ -264,10 +260,6 @@ public class searchTest {
         } catch (JSONException e) {
           throw new RuntimeException(e);
         }
-      }
-
-      @Override
-      public void onError(JSONObject error) {
       }
     });
     collection.search(filters, mock(ResponseListener.class));

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/searchTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/searchTest.java
@@ -8,6 +8,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+
 import java.net.URISyntaxException;
 
 import io.kuzzle.sdk.core.Kuzzle;
@@ -32,6 +37,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({android.util.Log.class})
 public class searchTest {
   private Kuzzle kuzzle;
   private Collection collection;
@@ -39,6 +46,7 @@ public class searchTest {
 
   @Before
   public void setUp() throws URISyntaxException {
+    PowerMockito.mockStatic(android.util.Log.class);
     Options opts = new Options();
     opts.setConnect(Mode.MANUAL);
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/updateDocumentTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/updateDocumentTest.java
@@ -124,21 +124,11 @@ public class updateDocumentTest {
         assertEquals(document.getId(), "42");
         assertEquals(document.getVersion(), 1337);
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     });
     collection.updateDocument("42", doc.serialize(), new Options(), new ResponseListener<Document>() {
       @Override
       public void onSuccess(Document document) {
         assertEquals(document.getId(), "42");
-      }
-
-      @Override
-      public void onError(JSONObject error) {
-
       }
     });
     verify(kuzzle, times(6)).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/updateDocumentTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/updateDocumentTest.java
@@ -8,6 +8,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+
 import java.net.URISyntaxException;
 
 import io.kuzzle.sdk.core.Collection;
@@ -32,6 +37,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({android.util.Log.class})
 public class updateDocumentTest {
   private Kuzzle kuzzle;
   private Collection collection;
@@ -39,6 +46,7 @@ public class updateDocumentTest {
 
   @Before
   public void setUp() throws URISyntaxException {
+    PowerMockito.mockStatic(android.util.Log.class);
     Options opts = new Options();
     opts.setConnect(Mode.MANUAL);
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/updateSpecificationsTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/updateSpecificationsTest.java
@@ -124,21 +124,11 @@ public class updateSpecificationsTest {
                 assertEquals(response, specifications);
                 assertEquals(response, specifications);
             }
-
-            @Override
-            public void onError(JSONObject error) {
-
-            }
         });
         collection.updateSpecifications(new JSONObject(), new Options(), new ResponseListener<JSONObject>() {
             @Override
             public void onSuccess(JSONObject response) {
                 assertEquals(response, specifications);
-            }
-
-            @Override
-            public void onError(JSONObject error) {
-
             }
         });
         ArgumentCaptor argument = ArgumentCaptor.forClass(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/updateSpecificationsTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/updateSpecificationsTest.java
@@ -8,6 +8,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+
 import java.net.URISyntaxException;
 
 import io.kuzzle.sdk.core.Collection;
@@ -30,6 +35,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({android.util.Log.class})
 public class updateSpecificationsTest {
     private Kuzzle kuzzle;
     private Collection collection;
@@ -37,6 +44,7 @@ public class updateSpecificationsTest {
 
     @Before
     public void setUp() throws URISyntaxException {
+        PowerMockito.mockStatic(android.util.Log.class);
         Options opts = new Options();
         opts.setConnect(Mode.MANUAL);
         KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/validateSpecificationsTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/validateSpecificationsTest.java
@@ -8,6 +8,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+
 import java.net.URISyntaxException;
 
 import io.kuzzle.sdk.core.Collection;
@@ -30,6 +35,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({android.util.Log.class})
 public class validateSpecificationsTest {
     private Kuzzle kuzzle;
     private Collection collection;
@@ -37,6 +44,7 @@ public class validateSpecificationsTest {
 
     @Before
     public void setUp() throws URISyntaxException {
+        PowerMockito.mockStatic(android.util.Log.class);
         Options opts = new Options();
         opts.setConnect(Mode.MANUAL);
         KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/validateSpecificationsTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/validateSpecificationsTest.java
@@ -117,11 +117,6 @@ public class validateSpecificationsTest {
                     e.printStackTrace();
                 }
             }
-
-            @Override
-            public void onError(JSONObject error) {
-
-            }
         });
         collection.validateSpecifications(new JSONObject(), new Options(), new ResponseListener<Boolean>() {
             @Override
@@ -131,11 +126,6 @@ public class validateSpecificationsTest {
                 } catch (JSONException e) {
                     e.printStackTrace();
                 }
-            }
-
-            @Override
-            public void onError(JSONObject error) {
-
             }
         });
         ArgumentCaptor argument = ArgumentCaptor.forClass(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataMapping/refreshTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataMapping/refreshTest.java
@@ -137,11 +137,6 @@ public class refreshTest {
           throw new RuntimeException(e);
         }
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     });
     dataMapping.refresh(new Options(), mock(ResponseListener.class));
     ArgumentCaptor argument = ArgumentCaptor.forClass(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDocument/existsTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDocument/existsTest.java
@@ -110,11 +110,6 @@ public class existsTest {
             public void onSuccess(Boolean exists) {
                 assertEquals(exists, true);
             }
-
-            @Override
-            public void onError(JSONObject error) {
-
-            }
         });
         doc.exists(mockListener);
         doc.exists(mock(Options.class), mockListener);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDocument/refreshTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDocument/refreshTest.java
@@ -123,11 +123,6 @@ public class refreshTest {
           e.printStackTrace();
         }
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     });
     doc.refresh(mockListener);
     doc.refresh(mock(Options.class), mockListener);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDocument/saveTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDocument/saveTest.java
@@ -99,11 +99,6 @@ public class saveTest {
       public void onSuccess(Document object) {
         assertEquals(object.getId(), "id-42");
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     });
     ArgumentCaptor argument = ArgumentCaptor.forClass(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class);
     verify(k, times(3)).query((io.kuzzle.sdk.core.Kuzzle.QueryArgs) argument.capture(), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));

--- a/src/test/java/io/kuzzle/test/core/KuzzleMemoryStorage/methodsTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleMemoryStorage/methodsTest.java
@@ -69,10 +69,6 @@ public class methodsTest {
       public void onSuccess(Long response) {
         assertEquals((long)response, expected);
       }
-
-      @Override
-      public void onError(JSONObject error) {
-      }
     };
   }
 
@@ -84,10 +80,6 @@ public class methodsTest {
       public void onSuccess(Integer response) {
         assertEquals((int)response, expected);
       }
-
-      @Override
-      public void onError(JSONObject error) {
-      }
     };
   }
 
@@ -98,10 +90,6 @@ public class methodsTest {
       @Override
       public void onSuccess(Boolean response) {
         assertEquals(response, expected);
-      }
-
-      @Override
-      public void onError(JSONObject error) {
       }
     };
   }
@@ -129,10 +117,6 @@ public class methodsTest {
       public void onSuccess(String response) {
         assertEquals(response, expected);
       }
-
-      @Override
-      public void onError(JSONObject error) {
-      }
     };
   }
 
@@ -144,10 +128,6 @@ public class methodsTest {
       public void onSuccess(String[] response) {
         assertArrayEquals(response, expected);
       }
-
-      @Override
-      public void onError(JSONObject error) {
-      }
     };
   }
 
@@ -158,10 +138,6 @@ public class methodsTest {
       @Override
       public void onSuccess(String[] response) {
         assertArrayEquals(response, expected);
-      }
-
-      @Override
-      public void onError(JSONObject error) {
       }
     };
   }
@@ -181,11 +157,6 @@ public class methodsTest {
           }
         }
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     };
   }
 
@@ -196,10 +167,6 @@ public class methodsTest {
       @Override
       public void onSuccess(Double response) {
         assertEquals(response, expected, 10e-12);
-      }
-
-      @Override
-      public void onError(JSONObject error) {
       }
     };
   }
@@ -216,11 +183,6 @@ public class methodsTest {
         catch(JSONException e) {
           fail(e.getMessage());
         }
-      }
-
-      @Override
-      public void onError(JSONObject error) {
-
       }
     };
   }
@@ -870,10 +832,6 @@ public class methodsTest {
       @Override
       public void onSuccess(JSONObject response) {
         assertEquals(response, result);
-      }
-
-      @Override
-      public void onError(JSONObject error) {
       }
     };
 
@@ -2015,11 +1973,6 @@ public class methodsTest {
       @Override
       public void onSuccess(Long[] response) {
         assertArrayEquals(response, new Long[]{Long.valueOf(123), Long.valueOf(456)});
-      }
-
-      @Override
-      public void onError(JSONObject error) {
-
       }
     });
   }

--- a/src/test/java/io/kuzzle/test/core/KuzzleRoom/countTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleRoom/countTest.java
@@ -37,11 +37,6 @@ public class countTest {
     public void onSuccess(Object response) {
 
     }
-
-    @Override
-    public void onError(JSONObject error) {
-
-    }
   });
   private JSONObject mockNotif = new JSONObject();
   private JSONObject  mockResponse = new JSONObject();

--- a/src/test/java/io/kuzzle/test/listeners/KuzzleSubscribeListenerTest.java
+++ b/src/test/java/io/kuzzle/test/listeners/KuzzleSubscribeListenerTest.java
@@ -4,6 +4,11 @@ import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+
 import io.kuzzle.sdk.core.Room;
 import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.SubscribeListener;
@@ -13,6 +18,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({android.util.Log.class})
 public class KuzzleSubscribeListenerTest {
 
   private SubscribeListener subListener;
@@ -21,6 +28,7 @@ public class KuzzleSubscribeListenerTest {
 
   @Before
   public void setUp() {
+    PowerMockito.mockStatic(android.util.Log.class);
     subListener = new SubscribeListener();
     callback = spy(new ResponseListener<Room>() {
       @Override

--- a/src/test/java/io/kuzzle/test/listeners/KuzzleSubscribeListenerTest.java
+++ b/src/test/java/io/kuzzle/test/listeners/KuzzleSubscribeListenerTest.java
@@ -27,11 +27,6 @@ public class KuzzleSubscribeListenerTest {
       public void onSuccess(Room response) {
 
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     });
   }
 

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/createCredentialsTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/createCredentialsTest.java
@@ -37,11 +37,6 @@ public class createCredentialsTest {
       public void onSuccess(Object response) {
 
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     };
   }
 

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/deleteCredentialsTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/deleteCredentialsTest.java
@@ -31,11 +31,6 @@ public class deleteCredentialsTest {
       public void onSuccess(Object response) {
 
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     };
   }
 

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/getAllCredentialFieldsTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/getAllCredentialFieldsTest.java
@@ -31,11 +31,6 @@ public class getAllCredentialFieldsTest {
       public void onSuccess(Object response) {
 
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     };
   }
 

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/getAllCredentialFieldsTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/getAllCredentialFieldsTest.java
@@ -13,10 +13,17 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({android.util.Log.class})
 public class getAllCredentialFieldsTest {
   private Kuzzle kuzzle;
   private Security kuzzleSecurity;
@@ -24,6 +31,7 @@ public class getAllCredentialFieldsTest {
 
   @Before
   public void setUp() {
+    PowerMockito.mockStatic(android.util.Log.class);
     kuzzle = mock(Kuzzle.class);
     kuzzleSecurity = new Security(kuzzle);
     listener = new ResponseListener() {

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/getCredentialFieldsTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/getCredentialFieldsTest.java
@@ -32,11 +32,6 @@ public class getCredentialFieldsTest {
       public void onSuccess(Object response) {
 
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     };
   }
 

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/getCredentialsTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/getCredentialsTest.java
@@ -31,11 +31,6 @@ public class getCredentialsTest {
       public void onSuccess(Object response) {
 
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     };
   }
 

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/hasCredentialsTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/hasCredentialsTest.java
@@ -31,11 +31,6 @@ public class hasCredentialsTest {
       public void onSuccess(Object response) {
 
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     };
   }
 

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/scrollProfilesTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/scrollProfilesTest.java
@@ -167,10 +167,6 @@ public class scrollProfilesTest {
                 assertEquals(result.getTotal(), 2);
                 assertEquals(result.getDocuments().get(1).getId(), "AVJAwyOvZAGQHg9Dhfw3");
             }
-
-            @Override
-            public void onError(JSONObject error) {
-            }
         });
         security.scrollProfiles(scroll, mock(ResponseListener.class));
         ArgumentCaptor argument = ArgumentCaptor.forClass(Kuzzle.QueryArgs.class);

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/scrollProfilesTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/scrollProfilesTest.java
@@ -8,6 +8,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+
 import java.net.URISyntaxException;
 
 import io.kuzzle.sdk.core.Kuzzle;
@@ -33,6 +38,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({android.util.Log.class})
 public class scrollProfilesTest {
     private Kuzzle kuzzle;
     private Security security;
@@ -43,6 +50,7 @@ public class scrollProfilesTest {
 
     @Before
     public void setUp() throws URISyntaxException {
+        PowerMockito.mockStatic(android.util.Log.class);
         Options opts = new Options();
         opts.setConnect(Mode.MANUAL);
         KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/scrollUsersTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/scrollUsersTest.java
@@ -167,10 +167,6 @@ public class scrollUsersTest {
                 assertEquals(result.getTotal(), 2);
                 assertEquals(result.getDocuments().get(1).getId(), "AVJAwyOvZAGQHg9Dhfw3");
             }
-
-            @Override
-            public void onError(JSONObject error) {
-            }
         });
         security.scrollUsers(scroll, mock(ResponseListener.class));
         ArgumentCaptor argument = ArgumentCaptor.forClass(Kuzzle.QueryArgs.class);

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/scrollUsersTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/scrollUsersTest.java
@@ -8,6 +8,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+
 import java.net.URISyntaxException;
 
 import io.kuzzle.sdk.core.Kuzzle;
@@ -33,6 +38,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({android.util.Log.class})
 public class scrollUsersTest {
     private Kuzzle kuzzle;
     private Security security;
@@ -43,6 +50,7 @@ public class scrollUsersTest {
 
     @Before
     public void setUp() throws URISyntaxException {
+        PowerMockito.mockStatic(android.util.Log.class);
         Options opts = new Options();
         opts.setConnect(Mode.MANUAL);
         KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/updateCredentialsTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/updateCredentialsTest.java
@@ -32,11 +32,6 @@ public class updateCredentialsTest {
       public void onSuccess(Object response) {
 
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     };
   }
 

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/validateCredentialsTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/validateCredentialsTest.java
@@ -33,11 +33,6 @@ public class validateCredentialsTest {
       public void onSuccess(Object response) {
 
       }
-
-      @Override
-      public void onError(JSONObject error) {
-
-      }
     };
   }
 


### PR DESCRIPTION
This PR converts the `ResponseListener` and `OnQueryDoneListener` objects from `interface` to `abstract class`, with a default error handler.
The `onSuccess` method remains abstract and must be implemented whenever a new listener is instantiated.
The default error handler prints the error JSON object on standard error output or, if the provided error object is null, it prints the current stack trace.

This object conversion removes the necessity of implementing a `onError` listener, which is often left empty and clutter the code unnecessarily, as it became painfully obvious to me when rewriting the code examples for our website.

I also removed all unnecessary `onError` overrides from unit tests to clean things up.