### PR TITLE
Fix Document.version

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can configure your Android project to get Kuzzle's Android SDK from jcenter 
     }
 
     dependencies {
-        compile 'io.kuzzle:sdk-android:3.0.5'
+        compile 'io.kuzzle:sdk-android:3.0.6'
     }
 
 ## Basic usage

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'jacoco-android'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'com.github.dcendents.android-maven'
-version = "3.0.5"
+version = "3.0.6"
 
 buildscript {
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'jacoco-android'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'com.github.dcendents.android-maven'
 version = "3.0.5"
+
 buildscript {
     repositories {
     	google()
@@ -48,13 +49,14 @@ android {
 }
 
 repositories {
+    google()
     jcenter()
 }
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     // Temporary using v21, until Travis supports v23+
-    implementation 'com.android.support:appcompat-v7:23.+'
+    implementation 'com.android.support:appcompat-v7:23.0.1'
     implementation 'io.socket:socket.io-client:1.0.0'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.hamcrest:hamcrest-junit:2.0.0.0'

--- a/src/main/java/io/kuzzle/sdk/core/Document.java
+++ b/src/main/java/io/kuzzle/sdk/core/Document.java
@@ -385,7 +385,7 @@ public class Document {
 
     if (this.content.has("version")) {
       Object version = this.content.get("version");
-      if (version instanceof Long) {
+      if (version instanceof Long || version instanceof Integer) {
         this.version = this.content.getLong("version");
         this.content.remove("version");
       }

--- a/src/main/java/io/kuzzle/sdk/core/Document.java
+++ b/src/main/java/io/kuzzle/sdk/core/Document.java
@@ -384,8 +384,11 @@ public class Document {
     }
 
     if (this.content.has("version")) {
-      this.version = this.content.getLong("version");
-      this.content.remove("version");
+      Object version = this.content.get("version");
+      if (version instanceof Long) {
+        this.version = this.content.getLong("version");
+        this.content.remove("version");
+      }
     }
 
     return this;


### PR DESCRIPTION
## What does this PR do ?

We always assume the `version` attribute of a document would be a long but users can set it to, for exemple, a string.
Because the SDK 4 is coming and to avoid a breaking change, we now ignore the version attribute if it is not a long to set in the Document class as if no version was given. The version still remain in the content of the document.
