### PR TITLE
Replace SocketIO by WebSocket and add SSL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,33 @@ You can configure your Android project to get Kuzzle's Android SDK from jcenter 
     }
 
     dependencies {
-        compile 'io.kuzzle:sdk-android:3.0.8'
+        compile 'io.kuzzle:sdk-android:3.0.9'
     }
 
 ## Basic usage
 
 ```java
 Kuzzle kuzzle = new Kuzzle("host", new ResponseListener<Void>() {
+@Override
+public void onSuccess(Void object) {
+    // Handle success
+    KuzzleDocument doc = new KuzzleDocument(dataCollection);
+    doc.setContent("foo", "bar").save();
+}
+
+@Override
+public void onError(JSONObject error) {
+    // Handle error
+}
+});
+```
+
+## SSL Connection
+
+```java
+Options options = new Options();
+options.setSsl(true);
+Kuzzle kuzzle = new Kuzzle("host", options, new ResponseListener<Void>() {
 @Override
 public void onSuccess(Void object) {
     // Handle success

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     // Temporary using v21, until Travis supports v23+
     implementation 'com.android.support:appcompat-v7:23.0.1'
-    implementation 'io.socket:socket.io-client:1.0.0'
+    implementation 'tech.gusavila92:java-android-websocket-client:1.2.2'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.hamcrest:hamcrest-junit:2.0.0.0'
     testImplementation 'org.mockito:mockito-core:1.9.5'

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'jacoco-android'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'com.github.dcendents.android-maven'
-version = "3.0.8"
+version = "3.0.9"
 
 buildscript {
     repositories {

--- a/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
+++ b/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
@@ -1345,7 +1345,7 @@ public class Kuzzle {
   protected WebSocketClient createSocket() throws URISyntaxException {
     URI uri = null;
     try {
-      uri = new URI("ws"+(this.isSsl ? "s" : "")+"://"+this.host+":"+this.port+"/");
+      uri = new URI((this.isSsl ? "wss" : "ws")+"://"+this.host+":"+this.port+"/");
     }
     catch (URISyntaxException e) {
       e.printStackTrace();

--- a/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
+++ b/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
@@ -1491,7 +1491,7 @@ public class Kuzzle {
     c.setTime(now);
     c.add(Calendar.SECOND, -MAX_EMIT_TIMEOUT);
 
-    if (this.jwtToken != null || listener != null) {
+    if (listener != null) {
       currentQueries.put(request.get("requestId").toString(), listener);
     }
 
@@ -1635,13 +1635,17 @@ public class Kuzzle {
   }
 
   protected Kuzzle addRoom(final String channel, EventListener listener) {
-    roomList.put(channel, listener);
+    if (channel != null) {
+      roomList.put(channel, listener);
+    }
 
     return this;
   }
 
   protected Kuzzle removeRoom(final String channel) {
-    roomList.remove(channel);
+    if (channel != null) {
+      roomList.remove(channel);
+    }
 
     return this;
   }

--- a/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
+++ b/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
@@ -326,101 +326,6 @@ public class Kuzzle {
 
     Kuzzle.this.state = States.CONNECTING;
 
-    /*
-    if (socket != null) {
-      socket.once(Socket.EVENT_CONNECT, new Emitter.Listener() {
-        @Override
-        public void call(Object... args) {
-          Kuzzle.this.state = States.CONNECTED;
-
-          Kuzzle.this.renewSubscriptions();
-          Kuzzle.this.dequeue();
-          Kuzzle.this.emitEvent(Event.connected);
-
-          if (Kuzzle.this.connectionCallback != null) {
-            Kuzzle.this.connectionCallback.onSuccess(null);
-          }
-        }
-      });
-    }
-    */
-
-    /*
-    if (socket != null) {
-      socket.once(Socket.EVENT_CONNECT_ERROR, new Emitter.Listener() {
-        @Override
-        public void call(Object... args) {
-          Kuzzle.this.state = States.ERROR;
-          Kuzzle.this.emitEvent(Event.error, args);
-
-          if (connectionCallback != null) {
-            JSONObject error = new JSONObject();
-            try {
-              error.put("message", ((EngineIOException) args[0]).getMessage());
-              error.put("code", ((EngineIOException) args[0]).code);
-            } catch (JSONException e) {
-              throw new RuntimeException(e);
-            }
-            connectionCallback.onError(error);
-          }
-        }
-      });
-    }
-    */
-
-    /*
-    if (socket != null) {
-      socket.once(Socket.EVENT_DISCONNECT, new Emitter.Listener() {
-        @Override
-        public void call(Object... args) {
-          Kuzzle.this.state = States.OFFLINE;
-          if (!Kuzzle.this.autoReconnect) {
-            Kuzzle.this.disconnect();
-          }
-          if (Kuzzle.this.autoQueue) {
-            Kuzzle.this.queuing = true;
-          }
-
-          Kuzzle.this.emitEvent(Event.disconnected);
-        }
-      });
-    }
-    */
-
-    /*
-    if (socket != null) {
-      socket.once(Socket.EVENT_RECONNECT, new Emitter.Listener() {
-        @Override
-        public void call(Object... args) {
-          Kuzzle.this.state = States.CONNECTED;
-
-          if (Kuzzle.this.jwtToken != null) {
-            Kuzzle.this.checkToken(jwtToken, new ResponseListener<TokenValidity>() {
-              @Override
-              public void onSuccess(TokenValidity response) {
-                if (!response.isValid()) {
-                  Kuzzle.this.jwtToken = null;
-                  Kuzzle.this.emitEvent(Event.tokenExpired);
-                }
-
-                Kuzzle.this.reconnect();
-              }
-
-              @Override
-              public void onError(JSONObject error) {
-                Kuzzle.this.jwtToken = null;
-                Kuzzle.this.emitEvent(Event.tokenExpired);
-                Kuzzle.this.reconnect();
-              }
-            });
-          } else {
-            Kuzzle.this.reconnect();
-          }
-        }
-      });
-    }
-    */
-
     if (socket != null) {
       socket.connect();
     }
@@ -1583,33 +1488,9 @@ public class Kuzzle {
 
     if (this.jwtToken != null || listener != null) {
       currentQueries.put(request.get("requestId").toString(), listener);
-      /*
-      socket.once(request.get("requestId").toString(), new Emitter.Listener() {
-        @Override
-        public void call(Object... args) {
-          try {
-            // checking token expiration
-            if (!((JSONObject) args[0]).isNull("error") && ((JSONObject) args[0]).getJSONObject("error").getString("message").equals("Token expired") && !((JSONObject) args[0]).getString("action").equals("logout")) {
-              emitEvent(Event.tokenExpired, listener);
-            }
-
-            if (listener != null) {
-              if (!((JSONObject) args[0]).isNull("error")) {
-                listener.onError(((JSONObject) args[0]).getJSONObject("error"));
-              } else {
-                listener.onSuccess((JSONObject) args[0]);
-              }
-            }
-          } catch (JSONException e) {
-            throw new RuntimeException(e);
-          }
-        }
-      });
-      */
     }
 
     socket.send(request.toString());
-    // socket.emit("kuzzle", request);
 
     // Track requests made to allow Room.subscribeToSelf to work
     this.requestHistory.put(request.getString("requestId"), new Date());

--- a/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
+++ b/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
@@ -39,10 +39,7 @@ import io.kuzzle.sdk.util.OfflineQueueLoader;
 import io.kuzzle.sdk.util.QueryObject;
 import io.kuzzle.sdk.util.QueueFilter;
 import io.kuzzle.sdk_android.BuildConfig;
-import io.socket.client.IO;
-import io.socket.client.Socket;
-import io.socket.emitter.Emitter;
-import io.socket.engineio.client.EngineIOException;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 /**
  * The type Kuzzle.
@@ -52,13 +49,18 @@ public class Kuzzle {
   private final int EVENT_TIMEOUT = 200;
 
   protected ConcurrentHashMap<Event, EventList> eventListeners = new ConcurrentHashMap<>();
-  protected Socket socket;
+
+  protected WebSocketClient socket;
+  protected ConcurrentHashMap<String, OnQueryDoneListener> currentQueries = new ConcurrentHashMap<>();
+  protected ConcurrentHashMap<String, EventListener> roomList = new ConcurrentHashMap<>();
+
   protected Map<String, Map<String, Collection>> collections = new ConcurrentHashMap<>();
   protected boolean autoReconnect = true;
   protected JSONObject headers = new JSONObject();
   protected JSONObject _volatile;
   protected String host;
   protected Integer port;
+  protected boolean isSsl;
   protected ResponseListener<Void> connectionCallback;
   protected States state = States.INITIALIZING;
   protected long reconnectionDelay;
@@ -153,7 +155,7 @@ public class Kuzzle {
    * @param host - Target host name or IP address
    * @param options - Request options
    * @param connectionCallback - On success callback listener
-   * @throws URISyntaxException 
+   * @throws URISyntaxException
    */
   public Kuzzle(@NonNull final String host, final Options options, final ResponseListener<Void> connectionCallback) throws URISyntaxException {
     if (host == null || host.isEmpty()) {
@@ -172,6 +174,7 @@ public class Kuzzle {
     this.headers = opt.getHeaders();
     this._volatile = opt.getVolatile();
     this.port = opt.getPort();
+    this.isSsl = opt.isSsl();
     this.queueMaxSize = opt.getQueueMaxSize();
     this.queueTTL = opt.getQueueTTL();
     this.reconnectionDelay = opt.getReconnectionDelay();
@@ -208,7 +211,7 @@ public class Kuzzle {
    *
    * @param host - Target Kuzzle host name or IP address
    * @param cb - On success connection callback listener
-   * @throws URISyntaxException 
+   * @throws URISyntaxException
    */
   public Kuzzle(@NonNull final String host, final ResponseListener<Void> cb) throws URISyntaxException {
     this(host, null, cb);
@@ -219,14 +222,14 @@ public class Kuzzle {
    *
    * @param host - Target Kuzzle host name or IP address
    * @param options - Request options
-   * @throws URISyntaxException 
+   * @throws URISyntaxException
    */
   public Kuzzle(@NonNull final String host, Options options) throws URISyntaxException {
     this(host, options, null);
   }
 
   /**
-   * Adds a listener to a Kuzzle global event. When an event is triggered, 
+   * Adds a listener to a Kuzzle global event. When an event is triggered,
    * listeners are called in the order of their insertion.
    *
    * @param kuzzleEvent - Name of the global event to subscribe to
@@ -305,7 +308,7 @@ public class Kuzzle {
    * Connects to a Kuzzle instance using the provided host and port.
    *
    * @return this
-   * @throws URISyntaxException 
+   * @throws URISyntaxException
    */
   public Kuzzle connect() throws URISyntaxException {
     if (!this.isValidState()) {
@@ -323,6 +326,7 @@ public class Kuzzle {
 
     Kuzzle.this.state = States.CONNECTING;
 
+    /*
     if (socket != null) {
       socket.once(Socket.EVENT_CONNECT, new Emitter.Listener() {
         @Override
@@ -339,7 +343,9 @@ public class Kuzzle {
         }
       });
     }
+    */
 
+    /*
     if (socket != null) {
       socket.once(Socket.EVENT_CONNECT_ERROR, new Emitter.Listener() {
         @Override
@@ -360,7 +366,9 @@ public class Kuzzle {
         }
       });
     }
+    */
 
+    /*
     if (socket != null) {
       socket.once(Socket.EVENT_DISCONNECT, new Emitter.Listener() {
         @Override
@@ -377,7 +385,9 @@ public class Kuzzle {
         }
       });
     }
+    */
 
+    /*
     if (socket != null) {
       socket.once(Socket.EVENT_RECONNECT, new Emitter.Listener() {
         @Override
@@ -409,6 +419,7 @@ public class Kuzzle {
         }
       });
     }
+    */
 
     if (socket != null) {
       socket.connect();
@@ -800,7 +811,7 @@ public class Kuzzle {
   }
 
   /**
-   * List data indexes 
+   * List data indexes
    *
    * @param options - Request options
    * @param listener - Response callback listener
@@ -945,8 +956,8 @@ public class Kuzzle {
         public void onError(JSONObject error) {
           try {
             emitEvent(Event.loginAttempt, new JSONObject()
-              .put("success", false)
-              .put("error", error));
+                    .put("success", false)
+                    .put("error", error));
           } catch (JSONException e) {
             throw new RuntimeException(e);
           }
@@ -992,8 +1003,8 @@ public class Kuzzle {
                 }
               } else {
                 emitEvent(Event.loginAttempt, new JSONObject()
-                  .put("success", false)
-                  .put("error", response.getJSONObject("error")));
+                        .put("success", false)
+                        .put("error", response.getJSONObject("error")));
                 if (loginCallback != null) {
                   loginCallback.onError(response.getJSONObject("error"));
                 }
@@ -1151,7 +1162,7 @@ public class Kuzzle {
    * @param options - Request options
    * @param listener - Response callback listener
    * @return this
-   * @throws JSONException 
+   * @throws JSONException
    */
   public Kuzzle query(final QueryArgs queryArgs, final JSONObject query, final Options options, final OnQueryDoneListener listener) throws JSONException {
     this.isValid();
@@ -1162,8 +1173,8 @@ public class Kuzzle {
     }
 
     object
-      .put("action", queryArgs.action)
-      .put("controller", queryArgs.controller);
+            .put("action", queryArgs.action)
+            .put("controller", queryArgs.controller);
 
     // Global volatile data
     JSONObject _volatile = new JSONObject();
@@ -1428,12 +1439,135 @@ public class Kuzzle {
    * @return created socket
    * @throws URISyntaxException
    */
-  protected Socket createSocket() throws URISyntaxException {
-    IO.Options opt = new IO.Options();
-    opt.forceNew = false;
-    opt.reconnection = this.autoReconnect;
-    opt.reconnectionDelay = this.reconnectionDelay;
-    return IO.socket("http://" + host + ":" + this.port, opt);
+  protected WebSocketClient createSocket() throws URISyntaxException {
+    URI uri = null;
+    try {
+      uri = new URI("ws"+(this.isSsl ? "s" : "")+"://"+this.host+":"+this.port+"/");
+    }
+    catch (URISyntaxException e) {
+      e.printStackTrace();
+    }
+    socket = new WebSocketClient(uri) {
+      @Override
+      public void onOpen() {
+        if (Kuzzle.this.state == States.OFFLINE) { // Reconnect
+          Kuzzle.this.state = States.CONNECTED;
+
+          if (Kuzzle.this.jwtToken != null) {
+            Kuzzle.this.checkToken(jwtToken, new ResponseListener<TokenValidity>() {
+              @Override
+              public void onSuccess(TokenValidity response) {
+                if (!response.isValid()) {
+                  Kuzzle.this.jwtToken = null;
+                  Kuzzle.this.emitEvent(Event.tokenExpired);
+                }
+
+                Kuzzle.this.reconnect();
+              }
+
+              @Override
+              public void onError(JSONObject error) {
+                Kuzzle.this.jwtToken = null;
+                Kuzzle.this.emitEvent(Event.tokenExpired);
+                Kuzzle.this.reconnect();
+              }
+            });
+          } else {
+            Kuzzle.this.reconnect();
+          }
+        } else {
+          Kuzzle.this.state = States.CONNECTED;
+
+          Kuzzle.this.renewSubscriptions();
+          Kuzzle.this.dequeue();
+          Kuzzle.this.emitEvent(Event.connected);
+
+          if (Kuzzle.this.connectionCallback != null) {
+            Kuzzle.this.connectionCallback.onSuccess(null);
+          }
+        }
+      }
+
+      @Override
+      public void onTextReceived(String message) {
+        try {
+          JSONObject json = new JSONObject(message);
+          OnQueryDoneListener listener = currentQueries.get(json.getString("requestId"));
+
+          if (listener != null) {
+            // checking token expiration
+            if (!json.isNull("error") && json.getJSONObject("error").getString("message").equals("Token expired") && !json.getString("action").equals("logout")) {
+              emitEvent(Event.tokenExpired, listener);
+            }
+
+            if (!json.isNull("error")) {
+              listener.onError(json.getJSONObject("error"));
+            } else {
+              listener.onSuccess(json);
+            }
+            currentQueries.remove(json.getString("requestId"));
+          }
+
+          EventListener l  = roomList.get(json.getString("room"));
+          if (l != null) {
+            l.trigger(new JSONObject(message));
+          }
+        } catch (JSONException e) {
+          throw new RuntimeException(e);
+        }
+      }
+
+      @Override
+      public void onBinaryReceived(byte[] data) {
+
+      }
+
+      @Override
+      public void onPingReceived(byte[] data) {
+
+      }
+
+      @Override
+      public void onPongReceived(byte[] data) {
+
+      }
+
+      @Override
+      public void onException(Exception e) {
+        Kuzzle.this.state = States.ERROR;
+        Kuzzle.this.emitEvent(Event.error, e.getMessage());
+
+        if (connectionCallback != null) {
+          JSONObject error = new JSONObject();
+          try {
+            error.put("message", e.getMessage());
+          } catch (JSONException ee) {
+            throw new RuntimeException(ee);
+          }
+          connectionCallback.onError(error);
+        }
+      }
+
+      @Override
+      public void onCloseReceived() {
+        Kuzzle.this.state = States.OFFLINE;
+        if (!Kuzzle.this.autoReconnect) {
+          Kuzzle.this.disconnect();
+        }
+        if (Kuzzle.this.autoQueue) {
+          Kuzzle.this.queuing = true;
+        }
+        currentQueries.clear();
+
+        Kuzzle.this.emitEvent(Event.disconnected);
+      }
+    };
+
+    if (this.autoReconnect) {
+      socket.enableAutomaticReconnection(this.reconnectionDelay);
+    }
+
+    return socket;
   }
 
   /**
@@ -1441,7 +1575,7 @@ public class Kuzzle {
    *
    * @param request - Request to emit
    * @param listener - Response callback listener
-   * @throws JSONException 
+   * @throws JSONException
    */
   protected void emitRequest(final JSONObject request, final OnQueryDoneListener listener) throws JSONException {
     Date now = new Date();
@@ -1450,6 +1584,8 @@ public class Kuzzle {
     c.add(Calendar.SECOND, -MAX_EMIT_TIMEOUT);
 
     if (this.jwtToken != null || listener != null) {
+      currentQueries.put(request.get("requestId").toString(), listener);
+      /*
       socket.once(request.get("requestId").toString(), new Emitter.Listener() {
         @Override
         public void call(Object... args) {
@@ -1471,9 +1607,11 @@ public class Kuzzle {
           }
         }
       });
+      */
     }
 
-    socket.emit("kuzzle", request);
+    socket.send(request.toString());
+    // socket.emit("kuzzle", request);
 
     // Track requests made to allow Room.subscribeToSelf to work
     this.requestHistory.put(request.getString("requestId"), new Date());
@@ -1576,7 +1714,7 @@ public class Kuzzle {
   }
 
   /**
-   * Delete a pending subscription 
+   * Delete a pending subscription
    *
    * @param id - Unique ID of the Room instance to delete
    * @return this
@@ -1612,12 +1750,24 @@ public class Kuzzle {
     return this;
   }
 
+  protected Kuzzle addRoom(final String channel, EventListener listener) {
+    roomList.put(channel, listener);
+
+    return this;
+  }
+
+  protected Kuzzle removeRoom(final String channel) {
+    roomList.remove(channel);
+
+    return this;
+  }
+
   /**
    * Connection socket getter
    *
    * @return Connection socket
    */
-  protected Socket getSocket() {
+  protected WebSocketClient getSocket() {
     return socket;
   }
 
@@ -1626,7 +1776,7 @@ public class Kuzzle {
    *
    * @param socket - New connection socket
    */
-  protected void setSocket(Socket socket) {
+  protected void setSocket(WebSocketClient socket) {
     this.socket = socket;
   }
 
@@ -1928,7 +2078,7 @@ public class Kuzzle {
    * Set a new JWT and trigger the 'loginAttempt' event.
    *
    * @param jwt - New authentication JSON Web Token
-   * @return this 
+   * @return this
    */
   public Kuzzle setJwtToken(final String jwt) {
     this.jwtToken = jwt;
@@ -1961,8 +2111,8 @@ public class Kuzzle {
    * Sets the authentication token from a Kuzzle response object
    *
    * @param response - A Kuzzle API response
-   * @return this 
-   * @throws JSONException 
+   * @return this
+   * @throws JSONException
    */
   public Kuzzle setJwtToken(@NonNull final JSONObject response) throws JSONException {
     JSONObject result;
@@ -1977,8 +2127,8 @@ public class Kuzzle {
       this.emitEvent(Event.loginAttempt, new JSONObject().put("success", true));
     } else {
       this.emitEvent(Event.loginAttempt, new JSONObject()
-        .put("success", false)
-        .put("error", "Cannot find a valid JWT token in the following object: " + response.toString())
+              .put("success", false)
+              .put("error", "Cannot find a valid JWT token in the following object: " + response.toString())
       );
     }
 
@@ -2521,7 +2671,7 @@ public class Kuzzle {
    *
    * @param action - API controller action name
    * @return JSONObject - Kuzzle.query() 1st argument object
-   * @throws JSONException 
+   * @throws JSONException
    */
   protected io.kuzzle.sdk.core.Kuzzle.QueryArgs buildQueryArgs(@NonNull final String action) throws JSONException {
     return buildQueryArgs(null, action);
@@ -2537,8 +2687,8 @@ public class Kuzzle {
   protected void discardRequest(final OnQueryDoneListener listener, JSONObject query) throws JSONException {
     if (listener != null) {
       JSONObject err = new JSONObject()
-        .put("status", 400)
-        .put("message", "Unable to execute request: not connected to a Kuzzle server.\nDiscarded request: " + query.toString());
+              .put("status", 400)
+              .put("message", "Unable to execute request: not connected to a Kuzzle server.\nDiscarded request: " + query.toString());
 
       listener.onError(err);
     }
@@ -2577,8 +2727,8 @@ public class Kuzzle {
   public Kuzzle createMyCredentials(@NonNull final String strategy, final JSONObject credentials, final Options options, final ResponseListener<JSONObject> listener) {
     try {
       JSONObject body = new JSONObject()
-        .put("strategy", strategy)
-        .put("body", credentials);
+              .put("strategy", strategy)
+              .put("body", credentials);
       Kuzzle.this.query(buildQueryArgs("auth", "createMyCredentials"), body, options, new OnQueryDoneListener() {
         @Override
         public void onSuccess(JSONObject response) {
@@ -2637,7 +2787,7 @@ public class Kuzzle {
   public Kuzzle deleteMyCredentials(@NonNull final String strategy, final Options options, final ResponseListener<JSONObject> listener) {
     try {
       JSONObject body = new JSONObject()
-        .put("strategy", strategy);
+              .put("strategy", strategy);
       Kuzzle.this.query(buildQueryArgs("auth", "deleteMyCredentials"), body, options, new OnQueryDoneListener() {
         @Override
         public void onSuccess(JSONObject response) {
@@ -2684,7 +2834,7 @@ public class Kuzzle {
     }
     try {
       JSONObject body = new JSONObject()
-        .put("strategy", strategy);
+              .put("strategy", strategy);
       Kuzzle.this.query(buildQueryArgs("auth", "getMyCredentials"), body, options, new OnQueryDoneListener() {
         @Override
         public void onSuccess(JSONObject response) {
@@ -2738,8 +2888,8 @@ public class Kuzzle {
   public Kuzzle updateMyCredentials(@NonNull final String strategy, final JSONObject credentials, final Options options, final ResponseListener<JSONObject> listener) {
     try {
       JSONObject body = new JSONObject()
-        .put("strategy", strategy)
-        .put("body", credentials);
+              .put("strategy", strategy)
+              .put("body", credentials);
       Kuzzle.this.query(buildQueryArgs("auth", "updateMyCredentials"), body, options, new OnQueryDoneListener() {
         @Override
         public void onSuccess(JSONObject response) {
@@ -2787,8 +2937,8 @@ public class Kuzzle {
     }
     try {
       JSONObject body = new JSONObject()
-        .put("strategy", strategy)
-        .put("body", credentials);
+              .put("strategy", strategy)
+              .put("body", credentials);
       Kuzzle.this.query(buildQueryArgs("auth", "validateMyCredentials"), body, options, new OnQueryDoneListener() {
         @Override
         public void onSuccess(JSONObject response) {

--- a/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
+++ b/src/main/java/io/kuzzle/sdk/core/Kuzzle.java
@@ -1395,7 +1395,12 @@ public class Kuzzle {
       public void onTextReceived(String message) {
         try {
           JSONObject json = new JSONObject(message);
-          OnQueryDoneListener listener = currentQueries.get(json.getString("requestId"));
+          OnQueryDoneListener listener = null;
+          if (json.has("requestId")) {
+            listener = currentQueries.get(json.getString("requestId"));
+          } else {
+            listener = currentQueries.get(json.getString("room"));
+          }
 
           if (listener != null) {
             // checking token expiration

--- a/src/main/java/io/kuzzle/sdk/core/Options.java
+++ b/src/main/java/io/kuzzle/sdk/core/Options.java
@@ -33,6 +33,8 @@ public class Options {
   private Long size = null;
   private Integer port = 7512;
   private String scroll = null;
+
+  private boolean ssl = false;
   private SearchResult previous = null;
   private String scrollId = null;
   private int retryOnConflict = 0;
@@ -488,6 +490,23 @@ public class Options {
    */
   public Integer getPort() {
     return this.port;
+  }
+
+  /**
+   * ssl property getter
+   * @return ssl property value
+   */
+  public boolean isSsl() {
+    return ssl;
+  }
+
+  /**
+   * ssl property setter
+   * @param  ssl New port value
+   * @return this
+   */
+  public void setSsl(boolean ssl) {
+    this.ssl = ssl;
   }
 
   /**

--- a/src/main/java/io/kuzzle/sdk/core/Room.java
+++ b/src/main/java/io/kuzzle/sdk/core/Room.java
@@ -287,14 +287,6 @@ public class Room {
                     callAfterRenew(args[0]);
                   }
                 });
-                /*
-                Room.this.kuzzle.getSocket().on(Room.this.channel, new Emitter.Listener() {
-                  @Override
-                  public void call(final Object... args) {
-                    callAfterRenew(args[0]);
-                  }
-                });
-                */
 
                 Room.this.dequeue();
               }
@@ -349,7 +341,6 @@ public class Room {
       final JSONObject data = new JSONObject().put("body", new JSONObject().put("roomId", this.roomId));
       this.kuzzle.addHeaders(data, this.headers);
 
-      //this.kuzzle.getSocket().off(Room.this.channel);
       this.kuzzle.removeRoom(Room.this.channel);
       this.kuzzle.deleteSubscription(this.roomId, this.id);
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/checkTokenTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/checkTokenTest.java
@@ -17,7 +17,7 @@ import io.kuzzle.sdk.enums.Mode;
 import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -38,7 +38,7 @@ public class checkTokenTest {
     options.setDefaultIndex("testIndex");
 
     kuzzle = new KuzzleExtend("localhost", options, null);
-    kuzzle.setSocket(mock(Socket.class));
+    kuzzle.setSocket(mock(WebSocketClient.class));
 
     listener = new ResponseListener<Object>() {
       @Override

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/constructorTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/constructorTest.java
@@ -17,7 +17,7 @@ import io.kuzzle.sdk.util.QueryObject;
 import io.kuzzle.sdk.util.QueueFilter;
 import io.kuzzle.test.testUtils.KuzzleExtend;
 import io.kuzzle.test.testUtils.QueryArgsHelper;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.*;
@@ -30,7 +30,7 @@ import static org.hamcrest.core.IsInstanceOf.instanceOf;
 
 public class constructorTest {
   private KuzzleExtend kuzzle;
-  private Socket s;
+  private WebSocketClient s;
   private ResponseListener listener;
 
   @Before
@@ -40,7 +40,7 @@ public class constructorTest {
     options.setPort(12345);
     options.setDefaultIndex("testIndex");
 
-    s = mock(Socket.class);
+    s = mock(WebSocketClient.class);
     kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(s);
 
@@ -134,7 +134,7 @@ public class constructorTest {
     jsonObj.put("requestId", "42");
 
     extended.query(QueryArgsHelper.makeQueryArgs("controller", "action"), jsonObj, options, null);
-    verify(s).emit(eq("kuzzle"), eq(jsonObj));
+    verify(s).send(eq(jsonObj.toString()));
     assertEquals(jsonObj.getJSONObject("volatile").getString("foo"), "bar");
   }
 
@@ -152,7 +152,7 @@ public class constructorTest {
     extended.setSocket(s);
     extended.setState(States.CONNECTED);
     extended.query(QueryArgsHelper.makeQueryArgs("controller", "action"), jsonObj, options);
-    verify(s).emit(eq("kuzzle"), eq(jsonObj));
+    verify(s).send(eq(jsonObj.toString()));
     assertEquals(jsonObj.getJSONObject("volatile").getString("foo"), "bar");
   }
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/createIndexTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/createIndexTest.java
@@ -6,7 +6,8 @@ import io.kuzzle.sdk.enums.Mode;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -32,7 +33,7 @@ public class createIndexTest {
     options.setConnect(Mode.MANUAL);
 
     kuzzle = new KuzzleExtend("localhost", options, null);
-    kuzzle.setSocket(mock(Socket.class));
+    kuzzle.setSocket(mock(WebSocketClient.class));
 
     listener = new ResponseListener<Object>() {
       @Override

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/createMyCredentialsTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/createMyCredentialsTest.java
@@ -6,7 +6,8 @@ import io.kuzzle.sdk.enums.Mode;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -41,7 +42,7 @@ public class createMyCredentialsTest {
     }
 
     kuzzle = new KuzzleExtend("localhost", options, null);
-    kuzzle.setSocket(mock(Socket.class));
+    kuzzle.setSocket(mock(WebSocketClient.class));
 
     listener = new ResponseListener<Object>() {
       @Override

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/deleteMyCredentialsTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/deleteMyCredentialsTest.java
@@ -6,7 +6,8 @@ import io.kuzzle.sdk.enums.Mode;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -31,7 +32,7 @@ public class deleteMyCredentialsTest {
     options.setConnect(Mode.MANUAL);
 
     kuzzle = new KuzzleExtend("localhost", options, null);
-    kuzzle.setSocket(mock(Socket.class));
+    kuzzle.setSocket(mock(WebSocketClient.class));
 
     listener = new ResponseListener<Object>() {
       @Override

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/factoriesTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/factoriesTest.java
@@ -10,14 +10,14 @@ import io.kuzzle.sdk.core.Options;
 import io.kuzzle.sdk.enums.Mode;
 import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 
 public class factoriesTest {
   private KuzzleExtend kuzzle;
-  private Socket s;
+  private WebSocketClient s;
   private ResponseListener listener;
 
   @Before
@@ -26,7 +26,7 @@ public class factoriesTest {
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");
 
-    s = mock(Socket.class);
+    s = mock(WebSocketClient.class);
     kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(s);
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/getAllStatisticsTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/getAllStatisticsTest.java
@@ -18,7 +18,7 @@ import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleExtend;
 import io.kuzzle.test.testUtils.QueryArgsHelper;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -41,7 +41,7 @@ public class getAllStatisticsTest {
     options.setDefaultIndex("testIndex");
 
     kuzzle = new KuzzleExtend("localhost", options, null);
-    kuzzle.setSocket(mock(Socket.class));
+    kuzzle.setSocket(mock(WebSocketClient.class));
     kuzzle.setState(States.CONNECTED);
 
     listener = new ResponseListener<Object>() {

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/getAutoRefreshTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/getAutoRefreshTest.java
@@ -18,7 +18,7 @@ import io.kuzzle.sdk.enums.Mode;
 import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -41,7 +41,7 @@ public class getAutoRefreshTest {
     options.setDefaultIndex("testIndex");
 
     kuzzle = new KuzzleExtend("localhost", options, null);
-    kuzzle.setSocket(mock(Socket.class));
+    kuzzle.setSocket(mock(WebSocketClient.class));
 
     listener = mock(ResponseListener.class);
   }

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/getLastStatisticsTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/getLastStatisticsTest.java
@@ -15,7 +15,7 @@ import io.kuzzle.sdk.enums.Mode;
 import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -37,7 +37,7 @@ public class getLastStatisticsTest {
     options.setDefaultIndex("testIndex");
 
     kuzzle = new KuzzleExtend("localhost", options, null);
-    kuzzle.setSocket(mock(Socket.class));
+    kuzzle.setSocket(mock(WebSocketClient.class));
 
     listener = new ResponseListener<Object>() {
       @Override

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/getMyCredentialsTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/getMyCredentialsTest.java
@@ -6,7 +6,8 @@ import io.kuzzle.sdk.enums.Mode;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -31,7 +32,7 @@ public class getMyCredentialsTest {
     options.setConnect(Mode.MANUAL);
 
     kuzzle = new KuzzleExtend("localhost", options, null);
-    kuzzle.setSocket(mock(Socket.class));
+    kuzzle.setSocket(mock(WebSocketClient.class));
 
     listener = new ResponseListener<Object>() {
       @Override

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/getServerInfoTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/getServerInfoTest.java
@@ -15,7 +15,7 @@ import io.kuzzle.sdk.enums.Mode;
 import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -37,7 +37,7 @@ public class getServerInfoTest {
     options.setDefaultIndex("testIndex");
 
     kuzzle = new KuzzleExtend("localhost", options, null);
-    kuzzle.setSocket(mock(Socket.class));
+    kuzzle.setSocket(mock(WebSocketClient.class));
 
     listener = new ResponseListener<Object>() {
       @Override

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/getStatisticsTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/getStatisticsTest.java
@@ -16,7 +16,7 @@ import io.kuzzle.sdk.enums.Mode;
 import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -37,7 +37,7 @@ public class getStatisticsTest {
     options.setDefaultIndex("testIndex");
 
     kuzzle = new KuzzleExtend("localhost", options, null);
-    kuzzle.setSocket(mock(Socket.class));
+    kuzzle.setSocket(mock(WebSocketClient.class));
 
     listener = new ResponseListener<Object>() {
       @Override

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/kuzzleWebViewTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/kuzzleWebViewTest.java
@@ -12,7 +12,7 @@ import io.kuzzle.sdk.core.Options;
 import io.kuzzle.sdk.enums.Mode;
 import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -22,7 +22,7 @@ public class kuzzleWebViewTest {
 
   private KuzzleExtend kuzzle;
   private KuzzleExtend.KuzzleWebViewClient webViewClient;
-  private Socket s;
+  private WebSocketClient s;
   private ResponseListener listener;
 
   @Before
@@ -31,7 +31,7 @@ public class kuzzleWebViewTest {
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");
 
-    s = mock(Socket.class);
+    s = mock(WebSocketClient.class);
     kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(s);
     webViewClient = kuzzle.getKuzzleWebViewClient();

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/listCollectionsTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/listCollectionsTest.java
@@ -16,7 +16,7 @@ import io.kuzzle.sdk.enums.Mode;
 import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -38,7 +38,7 @@ public class listCollectionsTest {
     options.setDefaultIndex("testIndex");
 
     kuzzle = new KuzzleExtend("localhost", options, null);
-    kuzzle.setSocket(mock(Socket.class));
+    kuzzle.setSocket(mock(WebSocketClient.class));
 
     listener = new ResponseListener<Object>() {
       @Override

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/listIndexesTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/listIndexesTest.java
@@ -16,7 +16,7 @@ import io.kuzzle.sdk.enums.Mode;
 import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -38,7 +38,7 @@ public class listIndexesTest {
     options.setDefaultIndex("testIndex");
 
     kuzzle = new KuzzleExtend("localhost", options, null);
-    kuzzle.setSocket(mock(Socket.class));
+    kuzzle.setSocket(mock(WebSocketClient.class));
 
     listener = new ResponseListener<Object>() {
       @Override

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/loginTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/loginTest.java
@@ -18,7 +18,7 @@ import io.kuzzle.sdk.listeners.EventListener;
 import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.verify;
 
 public class loginTest {
   private KuzzleExtend kuzzle;
-  private Socket s;
+  private WebSocketClient s;
   private ResponseListener listener;
 
   @Before
@@ -40,7 +40,7 @@ public class loginTest {
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");
 
-    s = mock(Socket.class);
+    s = mock(WebSocketClient.class);
     kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(s);
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/logoutTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/logoutTest.java
@@ -16,7 +16,7 @@ import io.kuzzle.sdk.enums.Mode;
 import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.verify;
 
 public class logoutTest {
   private KuzzleExtend kuzzle;
-  private Socket s;
+  private WebSocketClient s;
   private ResponseListener listener;
 
   @Before
@@ -38,7 +38,7 @@ public class logoutTest {
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");
 
-    s = mock(Socket.class);
+    s = mock(WebSocketClient.class);
     kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(s);
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/nowTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/nowTest.java
@@ -15,7 +15,7 @@ import io.kuzzle.sdk.enums.Mode;
 import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -28,7 +28,7 @@ import static org.mockito.Mockito.verify;
 
 public class nowTest {
   private KuzzleExtend kuzzle;
-  private Socket s;
+  private WebSocketClient s;
   private ResponseListener listener;
 
   @Before
@@ -37,7 +37,7 @@ public class nowTest {
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");
 
-    s = mock(Socket.class);
+    s = mock(WebSocketClient.class);
     kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(s);
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/offlineQueueLoaderTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/offlineQueueLoaderTest.java
@@ -45,24 +45,11 @@ public class offlineQueueLoaderTest {
     kuzzleExtend = extended;
   }
 
-  private void mockAnswer() {
-    doAnswer(new Answer() {
-      @Override
-      public Object answer(InvocationOnMock invocation) throws Throwable {
-        //Mock response
-        //Call callback with response
-        s.onOpen();
-        return s;
-      }
-    }).when(s).connect();
-  }
-
 
   @Test
   public void testOfflineQueueLoader() throws JSONException, URISyntaxException, InterruptedException {
     kuzzleExtend = spy(kuzzleExtend);
     kuzzleExtend.setAutoReplay(true);
-    mockAnswer();
 
     Options opts = new Options().setQueuable(true);
     kuzzleExtend.setState(States.OFFLINE);
@@ -72,6 +59,8 @@ public class offlineQueueLoaderTest {
     args.action = "bar";
     kuzzleExtend.query(args, new JSONObject(), opts, mock(OnQueryDoneListener.class));
 
+    kuzzleExtend.setState(States.READY);
+    kuzzleExtend.setAutoReplay(false);
     OfflineQueueLoader offlineQueueLoader = new OfflineQueueLoader() {
       @Override
       public KuzzleQueue<QueryObject> load() {
@@ -88,8 +77,7 @@ public class offlineQueueLoaderTest {
     };
     kuzzleExtend.setOfflineQueueLoader(offlineQueueLoader);
 
-    mockAnswer();
-    kuzzleExtend.connect();
+    kuzzleExtend.replayQueue();
     ArgumentCaptor argument = ArgumentCaptor.forClass(JSONObject.class);
     Thread.sleep(1000);
     verify(kuzzleExtend, times(2)).emitRequest((JSONObject) argument.capture(), any(OnQueryDoneListener.class));
@@ -99,9 +87,9 @@ public class offlineQueueLoaderTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testOfflineQueueLoaderIllegalRequestId() throws JSONException, URISyntaxException {
+
     kuzzleExtend = spy(kuzzleExtend);
     kuzzleExtend.setAutoReplay(true);
-    mockAnswer();
 
     Options opts = new Options().setQueuable(true);
     kuzzleExtend.setState(States.OFFLINE);
@@ -111,6 +99,8 @@ public class offlineQueueLoaderTest {
     args.action = "bar";
     kuzzleExtend.query(args, new JSONObject(), opts, mock(OnQueryDoneListener.class));
 
+    kuzzleExtend.setState(States.READY);
+    kuzzleExtend.setAutoReplay(false);
     OfflineQueueLoader offlineQueueLoader = new OfflineQueueLoader() {
       @Override
       public KuzzleQueue<QueryObject> load() {
@@ -127,15 +117,13 @@ public class offlineQueueLoaderTest {
     };
     kuzzleExtend.setOfflineQueueLoader(offlineQueueLoader);
 
-    mockAnswer();
-    kuzzleExtend.connect();
+    kuzzleExtend.replayQueue();
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testOfflineQueueLoaderIllegalController() throws JSONException, URISyntaxException {
     kuzzleExtend = spy(kuzzleExtend);
     kuzzleExtend.setAutoReplay(true);
-    mockAnswer();
 
     Options opts = new Options().setQueuable(true);
     kuzzleExtend.setState(States.OFFLINE);
@@ -145,6 +133,8 @@ public class offlineQueueLoaderTest {
     args.action = "bar";
     kuzzleExtend.query(args, new JSONObject(), opts, mock(OnQueryDoneListener.class));
 
+    kuzzleExtend.setState(States.READY);
+    kuzzleExtend.setAutoReplay(false);
     OfflineQueueLoader offlineQueueLoader = new OfflineQueueLoader() {
       @Override
       public KuzzleQueue<QueryObject> load() {
@@ -161,15 +151,14 @@ public class offlineQueueLoaderTest {
     };
     kuzzleExtend.setOfflineQueueLoader(offlineQueueLoader);
 
-    mockAnswer();
-    kuzzleExtend.connect();
+
+    kuzzleExtend.replayQueue();
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testOfflineQueueLoaderIllegalAction() throws JSONException, URISyntaxException {
     kuzzleExtend = spy(kuzzleExtend);
     kuzzleExtend.setAutoReplay(true);
-    mockAnswer();
 
     Options opts = new Options().setQueuable(true);
     kuzzleExtend.setState(States.OFFLINE);
@@ -179,6 +168,8 @@ public class offlineQueueLoaderTest {
     args.action = "bar";
     kuzzleExtend.query(args, new JSONObject(), opts, mock(OnQueryDoneListener.class));
 
+    kuzzleExtend.setState(States.READY);
+    kuzzleExtend.setAutoReplay(false);
     OfflineQueueLoader offlineQueueLoader = new OfflineQueueLoader() {
       @Override
       public KuzzleQueue<QueryObject> load() {
@@ -195,15 +186,13 @@ public class offlineQueueLoaderTest {
     };
     kuzzleExtend.setOfflineQueueLoader(offlineQueueLoader);
 
-    mockAnswer();
-    kuzzleExtend.connect();
+    kuzzleExtend.replayQueue();
   }
 
   @Test
   public void testOfflineQueueDuplicateRequestId() throws JSONException, URISyntaxException, InterruptedException {
     kuzzleExtend = spy(kuzzleExtend);
     kuzzleExtend.setAutoReplay(true);
-    mockAnswer();
 
     Options opts = new Options().setQueuable(true);
     kuzzleExtend.setState(States.OFFLINE);
@@ -213,6 +202,8 @@ public class offlineQueueLoaderTest {
     args.action = "bar";
     kuzzleExtend.query(args, new JSONObject().put("requestId", "42"), opts, mock(OnQueryDoneListener.class));
 
+    kuzzleExtend.setState(States.READY);
+    kuzzleExtend.setAutoReplay(false);
     OfflineQueueLoader offlineQueueLoader = new OfflineQueueLoader() {
       @Override
       public KuzzleQueue<QueryObject> load() {
@@ -229,8 +220,7 @@ public class offlineQueueLoaderTest {
     };
     kuzzleExtend.setOfflineQueueLoader(offlineQueueLoader);
 
-    mockAnswer();
-    kuzzleExtend.connect();
+    kuzzleExtend.replayQueue();
     ArgumentCaptor argument = ArgumentCaptor.forClass(JSONObject.class);
     Thread.sleep(1000);
     verify(kuzzleExtend, times(1)).emitRequest((JSONObject) argument.capture(), any(OnQueryDoneListener.class));

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/offlineQueueLoaderTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/offlineQueueLoaderTest.java
@@ -19,8 +19,7 @@ import io.kuzzle.sdk.state.States;
 import io.kuzzle.sdk.util.OfflineQueueLoader;
 import io.kuzzle.sdk.util.QueryObject;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
-import io.socket.emitter.Emitter;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -34,28 +33,28 @@ import static org.mockito.Mockito.verify;
 public class offlineQueueLoaderTest {
 
   private KuzzleExtend kuzzleExtend;
-  private Socket s;
+  private WebSocketClient s;
 
   @Before
   public void setUp() throws URISyntaxException {
     Options options = new Options();
     options.setConnect(Mode.MANUAL);
-    s = mock(Socket.class);
+    s = mock(WebSocketClient.class);
     KuzzleExtend extended = new KuzzleExtend("localhost", options, null);
     extended.setSocket(s);
     kuzzleExtend = extended;
   }
 
-  private void mockAnswer(final String event) {
+  private void mockAnswer() {
     doAnswer(new Answer() {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {
         //Mock response
         //Call callback with response
-        ((Emitter.Listener) invocation.getArguments()[1]).call(null, null);
+        s.onOpen();
         return s;
       }
-    }).when(s).once(eq(event), any(Emitter.Listener.class));
+    }).when(s).connect();
   }
 
 
@@ -63,7 +62,7 @@ public class offlineQueueLoaderTest {
   public void testOfflineQueueLoader() throws JSONException, URISyntaxException, InterruptedException {
     kuzzleExtend = spy(kuzzleExtend);
     kuzzleExtend.setAutoReplay(true);
-    mockAnswer(Socket.EVENT_RECONNECT);
+    mockAnswer();
 
     Options opts = new Options().setQueuable(true);
     kuzzleExtend.setState(States.OFFLINE);
@@ -89,7 +88,7 @@ public class offlineQueueLoaderTest {
     };
     kuzzleExtend.setOfflineQueueLoader(offlineQueueLoader);
 
-    mockAnswer(Socket.EVENT_RECONNECT);
+    mockAnswer();
     kuzzleExtend.connect();
     ArgumentCaptor argument = ArgumentCaptor.forClass(JSONObject.class);
     Thread.sleep(1000);
@@ -102,7 +101,7 @@ public class offlineQueueLoaderTest {
   public void testOfflineQueueLoaderIllegalRequestId() throws JSONException, URISyntaxException {
     kuzzleExtend = spy(kuzzleExtend);
     kuzzleExtend.setAutoReplay(true);
-    mockAnswer(Socket.EVENT_RECONNECT);
+    mockAnswer();
 
     Options opts = new Options().setQueuable(true);
     kuzzleExtend.setState(States.OFFLINE);
@@ -128,7 +127,7 @@ public class offlineQueueLoaderTest {
     };
     kuzzleExtend.setOfflineQueueLoader(offlineQueueLoader);
 
-    mockAnswer(Socket.EVENT_RECONNECT);
+    mockAnswer();
     kuzzleExtend.connect();
   }
 
@@ -136,7 +135,7 @@ public class offlineQueueLoaderTest {
   public void testOfflineQueueLoaderIllegalController() throws JSONException, URISyntaxException {
     kuzzleExtend = spy(kuzzleExtend);
     kuzzleExtend.setAutoReplay(true);
-    mockAnswer(Socket.EVENT_RECONNECT);
+    mockAnswer();
 
     Options opts = new Options().setQueuable(true);
     kuzzleExtend.setState(States.OFFLINE);
@@ -162,7 +161,7 @@ public class offlineQueueLoaderTest {
     };
     kuzzleExtend.setOfflineQueueLoader(offlineQueueLoader);
 
-    mockAnswer(Socket.EVENT_RECONNECT);
+    mockAnswer();
     kuzzleExtend.connect();
   }
 
@@ -170,7 +169,7 @@ public class offlineQueueLoaderTest {
   public void testOfflineQueueLoaderIllegalAction() throws JSONException, URISyntaxException {
     kuzzleExtend = spy(kuzzleExtend);
     kuzzleExtend.setAutoReplay(true);
-    mockAnswer(Socket.EVENT_RECONNECT);
+    mockAnswer();
 
     Options opts = new Options().setQueuable(true);
     kuzzleExtend.setState(States.OFFLINE);
@@ -196,7 +195,7 @@ public class offlineQueueLoaderTest {
     };
     kuzzleExtend.setOfflineQueueLoader(offlineQueueLoader);
 
-    mockAnswer(Socket.EVENT_RECONNECT);
+    mockAnswer();
     kuzzleExtend.connect();
   }
 
@@ -204,7 +203,7 @@ public class offlineQueueLoaderTest {
   public void testOfflineQueueDuplicateRequestId() throws JSONException, URISyntaxException, InterruptedException {
     kuzzleExtend = spy(kuzzleExtend);
     kuzzleExtend.setAutoReplay(true);
-    mockAnswer(Socket.EVENT_RECONNECT);
+    mockAnswer();
 
     Options opts = new Options().setQueuable(true);
     kuzzleExtend.setState(States.OFFLINE);
@@ -230,7 +229,7 @@ public class offlineQueueLoaderTest {
     };
     kuzzleExtend.setOfflineQueueLoader(offlineQueueLoader);
 
-    mockAnswer(Socket.EVENT_RECONNECT);
+    mockAnswer();
     kuzzleExtend.connect();
     ArgumentCaptor argument = ArgumentCaptor.forClass(JSONObject.class);
     Thread.sleep(1000);

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/queryTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/queryTest.java
@@ -5,16 +5,12 @@ import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import java.net.URISyntaxException;
 
 import io.kuzzle.sdk.core.Kuzzle;
 import io.kuzzle.sdk.core.Options;
-import io.kuzzle.sdk.enums.Event;
 import io.kuzzle.sdk.enums.Mode;
-import io.kuzzle.sdk.listeners.EventListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.sdk.util.QueueFilter;
@@ -24,7 +20,6 @@ import tech.gusavila92.websocketclient.WebSocketClient;
 import static junit.framework.Assert.assertNotNull;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -71,10 +66,10 @@ public class queryTest {
   public void shouldEmitTheRightRequest() throws JSONException {
     kuzzle.query(args, new JSONObject());
 
-    ArgumentCaptor argument = ArgumentCaptor.forClass(JSONObject.class);
-    verify(socket).send(argument.capture().toString());
+    ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
+    verify(socket).send(argument.capture());
 
-    JSONObject request = (JSONObject) argument.getValue();
+    JSONObject request = new JSONObject(argument.getValue());
     assertEquals(request.getString("controller"), args.controller);
     assertEquals(request.getString("action"), args.action);
     assertEquals(request.getJSONObject("volatile").length(), 1);
@@ -89,10 +84,10 @@ public class queryTest {
     args.index = "index";
     kuzzle.query(args, new JSONObject());
 
-    ArgumentCaptor argument = ArgumentCaptor.forClass(JSONObject.class);
-    verify(socket).send(argument.capture().toString());
+    ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
+    verify(socket).send(argument.capture());
 
-    JSONObject request = (JSONObject) argument.getValue();
+    JSONObject request = new JSONObject(argument.getValue());
     assertEquals(request.getString("controller"), args.controller);
     assertEquals(request.getString("action"), args.action);
     assertEquals(request.getString("index"), args.index);
@@ -107,10 +102,10 @@ public class queryTest {
     args.collection = "collection";
     kuzzle.query(args, new JSONObject());
 
-    ArgumentCaptor argument = ArgumentCaptor.forClass(JSONObject.class);
-    verify(socket).send(argument.capture().toString());
+    ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
+    verify(socket).send(argument.capture());
 
-    JSONObject request = (JSONObject) argument.getValue();
+    JSONObject request = new JSONObject(argument.getValue());
     assertEquals(request.getString("controller"), args.controller);
     assertEquals(request.getString("action"), args.action);
     assertEquals(request.getString("collection"), args.collection);
@@ -125,10 +120,10 @@ public class queryTest {
     kuzzle.setJwtToken("token");
     kuzzle.query(args, new JSONObject());
 
-    ArgumentCaptor argument = ArgumentCaptor.forClass(JSONObject.class);
-    verify(socket).send(argument.capture().toString());
+    ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
+    verify(socket).send(argument.capture());
 
-    JSONObject request = (JSONObject) argument.getValue();
+    JSONObject request = new JSONObject(argument.getValue());
     assertEquals(request.getString("controller"), args.controller);
     assertEquals(request.getString("action"), args.action);
     assertEquals(request.getJSONObject("volatile").length(), 1);
@@ -145,10 +140,10 @@ public class queryTest {
     args.action = "checkToken";
     kuzzle.query(args, new JSONObject());
 
-    ArgumentCaptor argument = ArgumentCaptor.forClass(JSONObject.class);
-    verify(socket).send(argument.capture().toString());
+    ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
+    verify(socket).send(argument.capture());
 
-    JSONObject request = (JSONObject) argument.getValue();
+    JSONObject request = new JSONObject(argument.getValue());
     assertEquals(request.getString("controller"), args.controller);
     assertEquals(request.getString("action"), args.action);
     assertEquals(request.getJSONObject("volatile").length(), 1);
@@ -168,10 +163,10 @@ public class queryTest {
     kuzzle.setVolatile(kuzzleVolatile);
     kuzzle.query(args, new JSONObject(), opts);
 
-    ArgumentCaptor argument = ArgumentCaptor.forClass(JSONObject.class);
-    verify(socket).send(argument.capture().toString());
+    ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
+    verify(socket).send(argument.capture());
 
-    JSONObject _volatile = ((JSONObject) argument.getValue()).getJSONObject("volatile");
+    JSONObject _volatile = new JSONObject(argument.getValue()).getJSONObject("volatile");
     assertEquals(_volatile.length(), 4);
     assertEquals(_volatile.getString("sdkVersion"), kuzzle.getSdkVersion());
     assertEquals(_volatile.getString("foo"), "bar"); // options take precedence over kuzzle volatile data
@@ -183,10 +178,10 @@ public class queryTest {
   public void shouldSendSdkVersionInVolatile() throws JSONException  {
     kuzzle.query(args, new JSONObject(), new Options());
 
-    ArgumentCaptor argument = ArgumentCaptor.forClass(JSONObject.class);
-    verify(socket).send(argument.capture().toString());
+    ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
+    verify(socket).send(argument.capture());
 
-    JSONObject _volatile = ((JSONObject) argument.getValue()).getJSONObject("volatile");
+    JSONObject _volatile = new JSONObject(argument.getValue()).getJSONObject("volatile");
     assertEquals(_volatile.length(), 1);
     assertEquals(_volatile.getString("sdkVersion"), kuzzle.getSdkVersion());
   }
@@ -198,10 +193,10 @@ public class queryTest {
 
     kuzzle.query(args, new JSONObject(), opts);
 
-    ArgumentCaptor argument = ArgumentCaptor.forClass(JSONObject.class);
-    verify(socket).send(argument.capture().toString());
+    ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
+    verify(socket).send(argument.capture());
 
-    String refresh = ((JSONObject) argument.getValue()).getString("refresh");
+    String refresh = new JSONObject(argument.getValue()).getString("refresh");
     assertEquals(refresh, optionsRefresh);
   }
 
@@ -213,10 +208,10 @@ public class queryTest {
 
     kuzzle.query(args, new JSONObject());
 
-    ArgumentCaptor argument = ArgumentCaptor.forClass(JSONObject.class);
-    verify(socket).send(argument.capture().toString());
+    ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
+    verify(socket).send(argument.capture());
 
-    assertEquals(((JSONObject) argument.getValue()).getString("foo"), "bar");
+    assertEquals(new JSONObject(argument.getValue()).getString("foo"), "bar");
   }
 
   @Test
@@ -260,30 +255,6 @@ public class queryTest {
     verify(kuzzleSpy, never()).emitRequest(any(JSONObject.class), any(OnQueryDoneListener.class));
     verify(filter).filter(any(JSONObject.class));
     assertEquals(kuzzleSpy.getOfflineQueue().size(), 0);
-  }
-
-  @Test
-  public void shouldTriggerTokenExpiredEvent() throws JSONException {
-    EventListener fake = spy(new EventListener() {
-      @Override
-      public void trigger(Object... args) {
-
-      }
-    });
-    kuzzle.addListener(Event.tokenExpired, fake);
-    doAnswer(new Answer() {
-      @Override
-      public Object answer(InvocationOnMock invocation) throws Throwable {
-        final JSONObject response = new JSONObject()
-            .put("error", new JSONObject()
-                .put("message", "Token expired"))
-            .put("action", "notlogout");
-        socket.onTextReceived(response.toString());
-        return null;
-      }
-    }).when(socket).send(any(String.class));
-    kuzzle.emitRequest(new JSONObject().put("requestId", "foo"), mock(OnQueryDoneListener.class));
-    verify(fake).trigger(any(Object.class));
   }
 
   @Test

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/queueManagementTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/queueManagementTest.java
@@ -88,6 +88,7 @@ public class queueManagementTest {
     options.setQueueTTL(10000);
     options.setReplayInterval(1);
     options.setConnect(Mode.MANUAL);
+    options.setQueuable(false);
     KuzzleExtend extended = new KuzzleExtend("localhost", options, null);
     extended.setSocket(s);
     extended.setState(States.CONNECTED);
@@ -108,7 +109,7 @@ public class queueManagementTest {
     extended.flushQueue();
     extended.stopQueuing();
     assertEquals(extended.getOfflineQueue().size(), 0);
-    extended.query(QueryArgsHelper.makeQueryArgs("test", "test"), query, null, null);
+    extended.query(QueryArgsHelper.makeQueryArgs("test", "test"), query, options, null);
     assertEquals(extended.getOfflineQueue().size(), 0);
   }
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/refreshIndexTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/refreshIndexTest.java
@@ -18,7 +18,7 @@ import io.kuzzle.sdk.enums.Mode;
 import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -41,7 +41,7 @@ public class refreshIndexTest {
     options.setDefaultIndex("testIndex");
 
     kuzzle = new KuzzleExtend("localhost", options, null);
-    kuzzle.setSocket(mock(Socket.class));
+    kuzzle.setSocket(mock(WebSocketClient.class));
 
     listener = mock(ResponseListener.class);
   }

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/setAutoRefreshTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/setAutoRefreshTest.java
@@ -17,7 +17,7 @@ import io.kuzzle.sdk.enums.Mode;
 import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -40,7 +40,7 @@ public class setAutoRefreshTest {
     options.setDefaultIndex("testIndex");
 
     kuzzle = new KuzzleExtend("localhost", options, null);
-    kuzzle.setSocket(mock(Socket.class));
+    kuzzle.setSocket(mock(WebSocketClient.class));
 
     listener = mock(ResponseListener.class);
   }

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/setJwtTokenTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/setJwtTokenTest.java
@@ -12,7 +12,7 @@ import io.kuzzle.sdk.core.Options;
 import io.kuzzle.sdk.enums.Event;
 import io.kuzzle.sdk.enums.Mode;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNull;
@@ -28,7 +28,7 @@ import static org.mockito.Mockito.verify;
 
 public class setJwtTokenTest {
   private KuzzleExtend kuzzle;
-  private Socket s;
+  private WebSocketClient s;
 
   @Before
   public void setUp() throws URISyntaxException {
@@ -36,7 +36,7 @@ public class setJwtTokenTest {
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");
 
-    s = mock(Socket.class);
+    s = mock(WebSocketClient.class);
     kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setSocket(s);
 

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/subscriptionsManagementTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/subscriptionsManagementTest.java
@@ -15,7 +15,7 @@ import io.kuzzle.sdk.core.Room;
 import io.kuzzle.sdk.enums.Mode;
 import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -31,7 +31,7 @@ public class subscriptionsManagementTest {
     options.setDefaultIndex("testIndex");
 
     kuzzle = new KuzzleExtend("localhost", options, null);
-    kuzzle.setSocket(mock(Socket.class));
+    kuzzle.setSocket(mock(WebSocketClient.class));
 
     listener = new ResponseListener<Object>() {
       @Override

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/unsetJwtTokenTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/unsetJwtTokenTest.java
@@ -15,7 +15,7 @@ import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.test.testUtils.KuzzleDataCollectionExtend;
 import io.kuzzle.test.testUtils.KuzzleExtend;
 import io.kuzzle.test.testUtils.RoomExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.verify;
 
 public class unsetJwtTokenTest {
   private KuzzleExtend kuzzle;
-  private Socket s;
+  private WebSocketClient s;
   private ConcurrentHashMap<String, Room> chp = new ConcurrentHashMap<>();
   private Room room;
 
@@ -37,7 +37,7 @@ public class unsetJwtTokenTest {
     options.setConnect(Mode.MANUAL);
     options.setDefaultIndex("testIndex");
 
-    s = mock(Socket.class);
+    s = mock(WebSocketClient.class);
     kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.getSubscriptions().put("1", chp);
     kuzzle.setSocket(s);

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/updateMyCredentialsTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/updateMyCredentialsTest.java
@@ -6,7 +6,8 @@ import io.kuzzle.sdk.enums.Mode;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -39,7 +40,7 @@ public class updateMyCredentialsTest {
     }
 
     kuzzle = new KuzzleExtend("localhost", options, null);
-    kuzzle.setSocket(mock(Socket.class));
+    kuzzle.setSocket(mock(WebSocketClient.class));
 
     listener = new ResponseListener<Object>() {
       @Override

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/validateMyCredentialsTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/validateMyCredentialsTest.java
@@ -6,7 +6,8 @@ import io.kuzzle.sdk.enums.Mode;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -39,7 +40,7 @@ public class validateMyCredentialsTest {
     }
 
     kuzzle = new KuzzleExtend("localhost", options, null);
-    kuzzle.setSocket(mock(Socket.class));
+    kuzzle.setSocket(mock(WebSocketClient.class));
 
     listener = new ResponseListener<Object>() {
       @Override

--- a/src/test/java/io/kuzzle/test/core/Kuzzle/whoAmiTest.java
+++ b/src/test/java/io/kuzzle/test/core/Kuzzle/whoAmiTest.java
@@ -15,7 +15,7 @@ import io.kuzzle.sdk.enums.Mode;
 import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -37,7 +37,7 @@ public class whoAmiTest {
     options.setDefaultIndex("testIndex");
 
     kuzzle = new KuzzleExtend("localhost", options, null);
-    kuzzle.setSocket(mock(Socket.class));
+    kuzzle.setSocket(mock(WebSocketClient.class));
 
     listener = new ResponseListener<Object>() {
       @Override

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/constructorTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/constructorTest.java
@@ -14,7 +14,7 @@ import io.kuzzle.sdk.enums.Mode;
 import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -36,7 +36,7 @@ public class constructorTest {
     Options opts = new Options();
     opts.setConnect(Mode.MANUAL);
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-    extended.setSocket(mock(Socket.class));
+    extended.setSocket(mock(WebSocketClient.class));
     extended.setState(States.CONNECTED);
 
     kuzzle = spy(extended);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/countTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/countTest.java
@@ -18,7 +18,7 @@ import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -41,7 +41,7 @@ public class countTest {
     Options opts = new Options();
     opts.setConnect(Mode.MANUAL);
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-    extended.setSocket(mock(Socket.class));
+    extended.setSocket(mock(WebSocketClient.class));
     extended.setState(States.CONNECTED);
 
     kuzzle = spy(extended);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/createDocumentTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/createDocumentTest.java
@@ -19,7 +19,7 @@ import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -41,7 +41,7 @@ public class createDocumentTest {
     Options opts = new Options();
     opts.setConnect(Mode.MANUAL);
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-    extended.setSocket(mock(Socket.class));
+    extended.setSocket(mock(WebSocketClient.class));
     extended.setState(States.CONNECTED);
 
     kuzzle = spy(extended);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/createTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/createTest.java
@@ -19,7 +19,7 @@ import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleExtend;
 import io.kuzzle.sdk.core.Kuzzle.QueryArgs;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -41,7 +41,7 @@ public class createTest {
     Options opts = new Options();
     opts.setConnect(Mode.MANUAL);
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-    extended.setSocket(mock(Socket.class));
+    extended.setSocket(mock(WebSocketClient.class));
     extended.setState(States.CONNECTED);
 
     kuzzle = spy(extended);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/deleteDocumentTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/deleteDocumentTest.java
@@ -19,7 +19,7 @@ import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleDataCollectionExtend;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -41,7 +41,7 @@ public class deleteDocumentTest {
     Options opts = new Options();
     opts.setConnect(Mode.MANUAL);
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-    extended.setSocket(mock(Socket.class));
+    extended.setSocket(mock(WebSocketClient.class));
     extended.setState(States.CONNECTED);
 
     kuzzle = spy(extended);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/deleteSpecificationsTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/deleteSpecificationsTest.java
@@ -18,7 +18,7 @@ import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleDataCollectionExtend;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -40,7 +40,7 @@ public class deleteSpecificationsTest {
         Options opts = new Options();
         opts.setConnect(Mode.MANUAL);
         KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-        extended.setSocket(mock(Socket.class));
+        extended.setSocket(mock(WebSocketClient.class));
         extended.setState(States.CONNECTED);
 
         kuzzle = spy(extended);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/documentExistsTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/documentExistsTest.java
@@ -18,7 +18,7 @@ import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -41,7 +41,7 @@ public class documentExistsTest {
         Options opts = new Options();
         opts.setConnect(Mode.MANUAL);
         KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-        extended.setSocket(mock(Socket.class));
+        extended.setSocket(mock(WebSocketClient.class));
         extended.setState(States.CONNECTED);
 
         kuzzle = spy(extended);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/factoriesTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/factoriesTest.java
@@ -18,14 +18,12 @@ import io.kuzzle.sdk.enums.Mode;
 import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class factoriesTest {
@@ -38,7 +36,7 @@ public class factoriesTest {
     Options opts = new Options();
     opts.setConnect(Mode.MANUAL);
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-    extended.setSocket(mock(Socket.class));
+    extended.setSocket(mock(WebSocketClient.class));
     extended.setState(States.CONNECTED);
 
     kuzzle = spy(extended);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/fetchDocument.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/fetchDocument.java
@@ -18,7 +18,7 @@ import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -41,7 +41,7 @@ public class fetchDocument {
     Options opts = new Options();
     opts.setConnect(Mode.MANUAL);
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-    extended.setSocket(mock(Socket.class));
+    extended.setSocket(mock(WebSocketClient.class));
     extended.setState(States.CONNECTED);
 
     kuzzle = spy(extended);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/getMappingTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/getMappingTest.java
@@ -16,7 +16,7 @@ import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -37,7 +37,7 @@ public class getMappingTest {
     Options opts = new Options();
     opts.setConnect(Mode.MANUAL);
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-    extended.setSocket(mock(Socket.class));
+    extended.setSocket(mock(WebSocketClient.class));
     extended.setState(States.CONNECTED);
     kuzzle = spy(extended);
     when(kuzzle.getHeaders()).thenReturn(new JSONObject());

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/getSpecificationsTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/getSpecificationsTest.java
@@ -18,7 +18,7 @@ import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -40,7 +40,7 @@ public class getSpecificationsTest {
         Options opts = new Options();
         opts.setConnect(Mode.MANUAL);
         KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-        extended.setSocket(mock(Socket.class));
+        extended.setSocket(mock(WebSocketClient.class));
         extended.setState(States.CONNECTED);
 
         kuzzle = spy(extended);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/mCreateDocumentTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/mCreateDocumentTest.java
@@ -19,7 +19,7 @@ import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -42,7 +42,7 @@ public class mCreateDocumentTest {
         Options opts = new Options();
         opts.setConnect(Mode.MANUAL);
         KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-        extended.setSocket(mock(Socket.class));
+        extended.setSocket(mock(WebSocketClient.class));
         extended.setState(States.CONNECTED);
 
         kuzzle = spy(extended);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/mCreateOrReplaceDocumentTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/mCreateOrReplaceDocumentTest.java
@@ -19,7 +19,7 @@ import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -42,7 +42,7 @@ public class mCreateOrReplaceDocumentTest {
         Options opts = new Options();
         opts.setConnect(Mode.MANUAL);
         KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-        extended.setSocket(mock(Socket.class));
+        extended.setSocket(mock(WebSocketClient.class));
         extended.setState(States.CONNECTED);
 
         kuzzle = spy(extended);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/mDeleteDocumentTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/mDeleteDocumentTest.java
@@ -19,7 +19,7 @@ import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleDataCollectionExtend;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -42,7 +42,7 @@ public class mDeleteDocumentTest {
         Options opts = new Options();
         opts.setConnect(Mode.MANUAL);
         KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-        extended.setSocket(mock(Socket.class));
+        extended.setSocket(mock(WebSocketClient.class));
         extended.setState(States.CONNECTED);
 
         kuzzle = spy(extended);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/mGetDocumentTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/mGetDocumentTest.java
@@ -19,7 +19,7 @@ import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -42,7 +42,7 @@ public class mGetDocumentTest {
         Options opts = new Options();
         opts.setConnect(Mode.MANUAL);
         KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-        extended.setSocket(mock(Socket.class));
+        extended.setSocket(mock(WebSocketClient.class));
         extended.setState(States.CONNECTED);
 
         kuzzle = spy(extended);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/mReplaceDocumentTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/mReplaceDocumentTest.java
@@ -19,7 +19,7 @@ import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -42,7 +42,7 @@ public class mReplaceDocumentTest {
         Options opts = new Options();
         opts.setConnect(Mode.MANUAL);
         KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-        extended.setSocket(mock(Socket.class));
+        extended.setSocket(mock(WebSocketClient.class));
         extended.setState(States.CONNECTED);
 
         kuzzle = spy(extended);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/mUpdateDocumentTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/mUpdateDocumentTest.java
@@ -19,7 +19,7 @@ import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -42,7 +42,7 @@ public class mUpdateDocumentTest {
         Options opts = new Options();
         opts.setConnect(Mode.MANUAL);
         KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-        extended.setSocket(mock(Socket.class));
+        extended.setSocket(mock(WebSocketClient.class));
         extended.setState(States.CONNECTED);
 
         kuzzle = spy(extended);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/publishMessageTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/publishMessageTest.java
@@ -21,7 +21,7 @@ import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -41,7 +41,7 @@ public class publishMessageTest {
     Options opts = new Options();
     opts.setConnect(Mode.MANUAL);
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-    extended.setSocket(mock(Socket.class));
+    extended.setSocket(mock(WebSocketClient.class));
     extended.setState(States.CONNECTED);
 
     kuzzle = spy(extended);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/replaceDocumentTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/replaceDocumentTest.java
@@ -19,7 +19,7 @@ import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -41,7 +41,7 @@ public class replaceDocumentTest {
     Options opts = new Options();
     opts.setConnect(Mode.MANUAL);
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-    extended.setSocket(mock(Socket.class));
+    extended.setSocket(mock(WebSocketClient.class));
     extended.setState(States.CONNECTED);
 
     kuzzle = spy(extended);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/scrollSpecificationsTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/scrollSpecificationsTest.java
@@ -18,7 +18,7 @@ import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -44,7 +44,7 @@ public class scrollSpecificationsTest {
         opts.setConnect(Mode.MANUAL);
         opts.setScroll("30s");
         KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-        extended.setSocket(mock(Socket.class));
+        extended.setSocket(mock(WebSocketClient.class));
         extended.setState(States.CONNECTED);
         kuzzle = spy(extended);
         when(kuzzle.getHeaders()).thenReturn(new JSONObject());

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/scrollTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/scrollTest.java
@@ -19,7 +19,7 @@ import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.responses.SearchResult;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -45,7 +45,7 @@ public class scrollTest {
     Options opts = new Options();
     opts.setConnect(Mode.MANUAL);
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-    extended.setSocket(mock(Socket.class));
+    extended.setSocket(mock(WebSocketClient.class));
     extended.setState(States.CONNECTED);
     kuzzle = spy(extended);
     when(kuzzle.getHeaders()).thenReturn(new JSONObject());

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/searchSpecificationsTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/searchSpecificationsTest.java
@@ -16,14 +16,12 @@ import io.kuzzle.sdk.core.Options;
 import io.kuzzle.sdk.enums.Mode;
 import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
-import io.kuzzle.sdk.responses.SearchResult;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -42,7 +40,7 @@ public class searchSpecificationsTest {
         Options opts = new Options();
         opts.setConnect(Mode.MANUAL);
         KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-        extended.setSocket(mock(Socket.class));
+        extended.setSocket(mock(WebSocketClient.class));
         extended.setState(States.CONNECTED);
         kuzzle = spy(extended);
         when(kuzzle.getHeaders()).thenReturn(new JSONObject());

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/searchTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/searchTest.java
@@ -19,7 +19,7 @@ import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.responses.SearchResult;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -42,7 +42,7 @@ public class searchTest {
     Options opts = new Options();
     opts.setConnect(Mode.MANUAL);
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-    extended.setSocket(mock(Socket.class));
+    extended.setSocket(mock(WebSocketClient.class));
     extended.setState(States.CONNECTED);
     kuzzle = spy(extended);
     when(kuzzle.getHeaders()).thenReturn(new JSONObject());

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/subscribeTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/subscribeTest.java
@@ -19,7 +19,7 @@ import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -41,7 +41,7 @@ public class subscribeTest {
     Options opts = new Options();
     opts.setConnect(Mode.MANUAL);
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-    extended.setSocket(mock(Socket.class));
+    extended.setSocket(mock(WebSocketClient.class));
     extended.setState(States.CONNECTED);
 
     kuzzle = spy(extended);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/truncateTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/truncateTest.java
@@ -18,7 +18,7 @@ import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -40,7 +40,7 @@ public class truncateTest {
     Options opts = new Options();
     opts.setConnect(Mode.MANUAL);
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-    extended.setSocket(mock(Socket.class));
+    extended.setSocket(mock(WebSocketClient.class));
     extended.setState(States.CONNECTED);
 
     kuzzle = spy(extended);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/updateDocumentTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/updateDocumentTest.java
@@ -20,7 +20,7 @@ import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.sdk.util.KuzzleJSONObject;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -42,7 +42,7 @@ public class updateDocumentTest {
     Options opts = new Options();
     opts.setConnect(Mode.MANUAL);
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-    extended.setSocket(mock(Socket.class));
+    extended.setSocket(mock(WebSocketClient.class));
     extended.setState(States.CONNECTED);
 
     kuzzle = spy(extended);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/updateSpecificationsTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/updateSpecificationsTest.java
@@ -18,7 +18,7 @@ import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -40,7 +40,7 @@ public class updateSpecificationsTest {
         Options opts = new Options();
         opts.setConnect(Mode.MANUAL);
         KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-        extended.setSocket(mock(Socket.class));
+        extended.setSocket(mock(WebSocketClient.class));
         extended.setState(States.CONNECTED);
 
         kuzzle = spy(extended);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/validateSpecificationsTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDataCollection/validateSpecificationsTest.java
@@ -18,7 +18,7 @@ import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -40,7 +40,7 @@ public class validateSpecificationsTest {
         Options opts = new Options();
         opts.setConnect(Mode.MANUAL);
         KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-        extended.setSocket(mock(Socket.class));
+        extended.setSocket(mock(WebSocketClient.class));
         extended.setState(States.CONNECTED);
 
         kuzzle = spy(extended);

--- a/src/test/java/io/kuzzle/test/core/KuzzleDocument/deleteTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDocument/deleteTest.java
@@ -19,7 +19,7 @@ import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -41,7 +41,7 @@ public class deleteTest {
     opts.setConnect(Mode.MANUAL);
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setState(States.CONNECTED);
-    extended.setSocket(mock(Socket.class));
+    extended.setSocket(mock(WebSocketClient.class));
     k = spy(extended);
     doc = new Document(new Collection(k, "test", "index"));
   }

--- a/src/test/java/io/kuzzle/test/core/KuzzleDocument/existsTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDocument/existsTest.java
@@ -19,10 +19,9 @@ import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -43,7 +42,7 @@ public class existsTest {
         opts.setConnect(Mode.MANUAL);
         KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
         extended.setState(States.CONNECTED);
-        extended.setSocket(mock(Socket.class));
+        extended.setSocket(mock(WebSocketClient.class));
         k = spy(extended);
         mockListener = mock(ResponseListener.class);
         doc = new Document(new Collection(k, "test", "index"));

--- a/src/test/java/io/kuzzle/test/core/KuzzleDocument/publishTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDocument/publishTest.java
@@ -16,7 +16,7 @@ import io.kuzzle.sdk.enums.Mode;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -37,7 +37,7 @@ public class publishTest {
     opts.setConnect(Mode.MANUAL);
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setState(States.CONNECTED);
-    extended.setSocket(mock(Socket.class));
+    extended.setSocket(mock(WebSocketClient.class));
     k = spy(extended);
     doc = new Document(new Collection(k, "test", "index"));
   }

--- a/src/test/java/io/kuzzle/test/core/KuzzleDocument/refreshTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDocument/refreshTest.java
@@ -19,7 +19,7 @@ import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -43,7 +43,7 @@ public class refreshTest {
     opts.setConnect(Mode.MANUAL);
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setState(States.CONNECTED);
-    extended.setSocket(mock(Socket.class));
+    extended.setSocket(mock(WebSocketClient.class));
     k = spy(extended);
     mockListener = mock(ResponseListener.class);
     doc = new Document(new Collection(k, "test", "index"));

--- a/src/test/java/io/kuzzle/test/core/KuzzleDocument/saveTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDocument/saveTest.java
@@ -19,7 +19,7 @@ import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -41,7 +41,7 @@ public class saveTest {
     opts.setConnect(Mode.MANUAL);
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setState(States.CONNECTED);
-    extended.setSocket(mock(Socket.class));
+    extended.setSocket(mock(WebSocketClient.class));
     k = spy(extended);
     mockListener = mock(ResponseListener.class);
     doc = new Document(new Collection(k, "test", "index"));

--- a/src/test/java/io/kuzzle/test/core/KuzzleDocument/subscribeTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleDocument/subscribeTest.java
@@ -20,7 +20,7 @@ import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -43,7 +43,7 @@ public class subscribeTest {
     opts.setConnect(Mode.MANUAL);
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
     extended.setState(States.CONNECTED);
-    extended.setSocket(mock(Socket.class));
+    extended.setSocket(mock(WebSocketClient.class));
     k = spy(extended);
     mockCollection = mock(Collection.class);
     doc = new Document(new Collection(k, "test", "index"));

--- a/src/test/java/io/kuzzle/test/core/KuzzleRoom/countTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleRoom/countTest.java
@@ -18,7 +18,7 @@ import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleExtend;
 import io.kuzzle.test.testUtils.RoomExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -63,7 +63,7 @@ public class countTest {
         .put("requestId", "42");
     mockResponse.put("result", new JSONObject().put("channel", "channel").put("roomId", "42"));
     k = spy(new KuzzleExtend("localhost", null, null));
-    k.setSocket(mock(Socket.class));
+    k.setSocket(mock(WebSocketClient.class));
     k.setState(States.CONNECTED);
     when(k.getHeaders()).thenReturn(new JSONObject());
     room = new RoomExtend(new Collection(k, "test", "index"));
@@ -79,7 +79,7 @@ public class countTest {
     Options opts = new Options();
     opts.setConnect(Mode.MANUAL);
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-    extended.setSocket(mock(Socket.class));
+    extended.setSocket(mock(WebSocketClient.class));
     extended.setState(States.CONNECTED);
     extended = spy(extended);
     room = new RoomExtend(new Collection(extended, "test", "index"));
@@ -142,7 +142,7 @@ public class countTest {
     when(o.put(any(String.class), any(Object.class))).thenReturn(new JSONObject());
 
     KuzzleExtend extended = new KuzzleExtend("localhost", null, null);
-    extended.setSocket(mock(Socket.class));
+    extended.setSocket(mock(WebSocketClient.class));
     extended.setState(States.CONNECTED);
     extended = spy(extended);
     room = new RoomExtend(new Collection(extended, "test", "index"));

--- a/src/test/java/io/kuzzle/test/core/KuzzleRoom/notificationHandlerTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleRoom/notificationHandlerTest.java
@@ -22,8 +22,7 @@ import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleExtend;
 import io.kuzzle.test.testUtils.RoomExtend;
-import io.socket.client.Socket;
-import io.socket.emitter.Emitter;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.atLeastOnce;
@@ -84,7 +83,7 @@ public class notificationHandlerTest {
     Options opts = new Options();
     opts.setConnect(Mode.MANUAL);
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-    Socket s = mock(Socket.class);
+    WebSocketClient s = mock(WebSocketClient.class);
     extended.setSocket(s);
     extended.setState(States.CONNECTED);
     extended = spy(extended);
@@ -100,7 +99,7 @@ public class notificationHandlerTest {
     Options opts = new Options();
     opts.setConnect(Mode.MANUAL);
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-    Socket s = mock(Socket.class);
+    WebSocketClient s = mock(WebSocketClient.class);
     extended.setSocket(s);
     extended.setState(States.CONNECTED);
     extended = spy(extended);
@@ -119,16 +118,6 @@ public class notificationHandlerTest {
         return null;
       }
     }).when(extended).query(any(io.kuzzle.sdk.core.Kuzzle.QueryArgs.class), any(JSONObject.class), any(Options.class), any(OnQueryDoneListener.class));
-    doAnswer(new Answer() {
-      @Override
-      public Object answer(InvocationOnMock invocation) throws Throwable {
-        //Call callback with response
-        ((Emitter.Listener) invocation.getArguments()[1]).call(mockNotif);
-        verify(room).callAfterRenew(any(Object.class));
-
-        return null;
-      }
-    }).when(s).on(any(String.class), any(Emitter.Listener.class));
     room.renew(listener);
   }
 
@@ -157,7 +146,7 @@ public class notificationHandlerTest {
     Options opts = new Options();
     opts.setConnect(Mode.MANUAL);
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-    Socket s = mock(Socket.class);
+    WebSocketClient s = mock(WebSocketClient.class);
     extended.setSocket(s);
     extended.setState(States.CONNECTED);
     extended = spy(extended);

--- a/src/test/java/io/kuzzle/test/core/KuzzleRoom/renewTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleRoom/renewTest.java
@@ -23,8 +23,7 @@ import io.kuzzle.sdk.responses.NotificationResponse;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleExtend;
 import io.kuzzle.test.testUtils.RoomExtend;
-import io.socket.client.Socket;
-import io.socket.emitter.Emitter;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -74,7 +73,7 @@ public class renewTest {
   public void testRenew() throws JSONException, URISyntaxException {
     Options options = new Options();
     options.setConnect(Mode.MANUAL);
-    Socket s = mock(Socket.class);
+    WebSocketClient s = mock(WebSocketClient.class);
     KuzzleExtend kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setState(States.CONNECTED);
     kuzzle.setSocket(s);
@@ -82,14 +81,6 @@ public class renewTest {
     final Kuzzle kuzzleSpy = spy(kuzzle);
     Room testRoom = new Room(new Collection(kuzzleSpy, "collection", "index"));
 
-    doAnswer(new Answer() {
-      @Override
-      public Object answer(InvocationOnMock invocation) throws Throwable {
-        //Call callback with response
-        ((Emitter.Listener) invocation.getArguments()[1]).call(mockNotif);
-        return null;
-      }
-    }).when(s).on(any(String.class), any(Emitter.Listener.class));
     doAnswer(new Answer() {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {
@@ -117,7 +108,7 @@ public class renewTest {
     options.setConnect(Mode.MANUAL);
     KuzzleExtend kuzzle = new KuzzleExtend("localhost", options, null);
     kuzzle.setState(States.CONNECTED);
-    kuzzle.setSocket(mock(Socket.class));
+    kuzzle.setSocket(mock(WebSocketClient.class));
 
     final Kuzzle kuzzleSpy = spy(kuzzle);
     RoomExtend testRoom = new RoomExtend(new Collection(kuzzleSpy, "collection", "index"));
@@ -145,7 +136,7 @@ public class renewTest {
     Options opts = new Options();
     opts.setConnect(Mode.MANUAL);
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-    extended.setSocket(mock(Socket.class));
+    extended.setSocket(mock(WebSocketClient.class));
     extended.setState(States.CONNECTED);
     extended = spy(extended);
     room = new RoomExtend(new Collection(extended, "test", "index"));

--- a/src/test/java/io/kuzzle/test/core/KuzzleRoom/unsubscribeTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleRoom/unsubscribeTest.java
@@ -21,7 +21,7 @@ import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleExtend;
 import io.kuzzle.test.testUtils.RoomExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -64,7 +64,7 @@ public class unsubscribeTest {
   public void testUnsubscribe() throws JSONException, URISyntaxException {
     Options opts = new Options();
     opts.setConnect(Mode.MANUAL);
-    Socket s = mock(Socket.class);
+    WebSocketClient s = mock(WebSocketClient.class);
 
     KuzzleExtend kuzzle = new KuzzleExtend("localhost", opts, null);
     kuzzle.setState(States.CONNECTED);
@@ -86,7 +86,7 @@ public class unsubscribeTest {
     Options opts = new Options();
     opts.setConnect(Mode.MANUAL);
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-    extended.setSocket(mock(Socket.class));
+    extended.setSocket(mock(WebSocketClient.class));
     extended.setState(States.CONNECTED);
     extended = spy(extended);
     room = new RoomExtend(new Collection(extended, "test", "index"));
@@ -119,7 +119,7 @@ public class unsubscribeTest {
   public void testUnsubscribeWithPendingSubscriptions() throws URISyntaxException, JSONException {
     Options opts = new Options();
     opts.setConnect(Mode.MANUAL);
-    Socket s = mock(Socket.class);
+    WebSocketClient s = mock(WebSocketClient.class);
 
     KuzzleExtend kuzzle = new KuzzleExtend("localhost", opts, null);
     kuzzle.setState(States.CONNECTED);
@@ -141,7 +141,7 @@ public class unsubscribeTest {
     Options opts = new Options();
     opts.setConnect(Mode.MANUAL);
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-    extended.setSocket(mock(Socket.class));
+    extended.setSocket(mock(WebSocketClient.class));
     extended.setState(States.CONNECTED);
     extended = spy(extended);
     doThrow(JSONException.class).when(extended).getSocket();
@@ -155,7 +155,7 @@ public class unsubscribeTest {
     Options opts = new Options();
     opts.setConnect(Mode.MANUAL);
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-    extended.setSocket(mock(Socket.class));
+    extended.setSocket(mock(WebSocketClient.class));
     extended.setState(States.CONNECTED);
     extended = spy(extended);
 
@@ -170,7 +170,7 @@ public class unsubscribeTest {
     Options opts = new Options();
     opts.setConnect(Mode.MANUAL);
     KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-    extended.setSocket(mock(Socket.class));
+    extended.setSocket(mock(WebSocketClient.class));
     extended.setState(States.CONNECTED);
     extended = spy(extended);
     doThrow(JSONException.class).when(extended).getPendingSubscriptions();

--- a/src/test/java/io/kuzzle/test/core/KuzzleRoom/unsubscribeTest.java
+++ b/src/test/java/io/kuzzle/test/core/KuzzleRoom/unsubscribeTest.java
@@ -144,7 +144,7 @@ public class unsubscribeTest {
     extended.setSocket(mock(WebSocketClient.class));
     extended.setState(States.CONNECTED);
     extended = spy(extended);
-    doThrow(JSONException.class).when(extended).getSocket();
+    doThrow(JSONException.class).when(extended).removeRoom(any(String.class));
     room = new RoomExtend(new Collection(extended, "test", "index"));
     room.setRoomId("foobar");
     room.superUnsubscribe();

--- a/src/test/java/io/kuzzle/test/listeners/KuzzleListenerTest.java
+++ b/src/test/java/io/kuzzle/test/listeners/KuzzleListenerTest.java
@@ -18,86 +18,94 @@ import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.sdk.util.QueryObject;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
-import io.socket.emitter.Emitter;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 public class KuzzleListenerTest {
   private Kuzzle kuzzle;
   private KuzzleExtend kuzzleExtend;
-  private Socket s;
+  private Kuzzle kuzzleSpy;
+  private WebSocketClient s = mock(WebSocketClient.class);
   private io.kuzzle.sdk.util.Event event;
+  private io.kuzzle.sdk.util.Event eventSpy;
 
   @Before
   public void setUp() throws URISyntaxException {
     Options options = new Options();
     options.setConnect(Mode.MANUAL);
-    s = mock(Socket.class);
     KuzzleExtend extended = new KuzzleExtend("localhost", options, null);
     extended.setSocket(s);
     kuzzle = extended;
     kuzzleExtend = extended;
   }
 
-  private void mockAnswer(final String event) {
+  private void mockAnswer(Event e) {
+    event = new io.kuzzle.sdk.util.Event(e) {
+      @Override
+      public void trigger(Object... args) {
+
+      }
+    };
+    eventSpy = spy(event);
     doAnswer(new Answer() {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {
-        //Mock response
-        //Call callback with response
-        ((Emitter.Listener) invocation.getArguments()[1]).call(null, null);
+        eventSpy.trigger();
         return s;
       }
-    }).when(s).once(eq(event), any(Emitter.Listener.class));
+    }).when(s).connect();
   }
 
   @Test
   public void testCONNECTEDevent() throws URISyntaxException {
-    mockAnswer(Socket.EVENT_CONNECT);
-    event = mock(io.kuzzle.sdk.util.Event.class);
+    mockAnswer(Event.connected);
     kuzzle.addListener(Event.connected, event);
     kuzzle.connect();
-    verify(event, times(1)).trigger();
+    verify(eventSpy, times(1)).trigger();
   }
 
   @Test
   public void testERRORevent() throws URISyntaxException {
-    mockAnswer(Socket.EVENT_CONNECT_ERROR);
-    event = mock(io.kuzzle.sdk.util.Event.class);
+    mockAnswer(Event.error);
     kuzzle.addListener(Event.error, event);
     kuzzle.connect();
-    verify(event, times(1)).trigger(null, null);
+    verify(eventSpy, times(1)).trigger();
   }
 
   @Test
   public void testDISCONNECTevent() throws URISyntaxException {
-    mockAnswer(Socket.EVENT_DISCONNECT);
-    event = mock(io.kuzzle.sdk.util.Event.class);
+    mockAnswer(Event.disconnected);
     kuzzle.addListener(Event.disconnected, event);
     kuzzle.connect();
-    verify(event, times(1)).trigger();
+    verify(eventSpy, times(1)).trigger();
   }
 
   @Test
   public void testRECONNECTevent() throws URISyntaxException {
-    mockAnswer(Socket.EVENT_RECONNECT);
-    event = mock(io.kuzzle.sdk.util.Event.class);
+    mockAnswer(Event.reconnected);
     kuzzle.addListener(Event.reconnected, event);
     kuzzle.connect();
-    verify(event, times(1)).trigger();
+    verify(eventSpy, times(1)).trigger();
   }
 
   @Test
   public void testOfflineQueuePush() throws JSONException {
-    event = mock(io.kuzzle.sdk.util.Event.class);
-    kuzzleExtend.addListener(Event.offlineQueuePush, event);
+    event = new io.kuzzle.sdk.util.Event(Event.offlineQueuePush) {
+      @Override
+      public void trigger(Object... args) {
+
+      }
+    };
+    eventSpy = spy(event);
+    kuzzleExtend.addListener(Event.offlineQueuePush, eventSpy);
 
     Options opts = new Options().setQueuable(true);
     kuzzleExtend.setState(States.OFFLINE);
@@ -108,16 +116,22 @@ public class KuzzleListenerTest {
     args.action = "bar";
     kuzzleExtend.query(args, new JSONObject(), opts, mock(OnQueryDoneListener.class));
     ArgumentCaptor argument = ArgumentCaptor.forClass(QueryObject.class);
-    verify(event).trigger(argument.capture());
+    verify(eventSpy).trigger(argument.capture());
     assertEquals(((QueryObject) argument.getValue()).getQuery().getString("action"), "bar");
   }
 
   @Test
   public void testOfflineQueuePop() throws JSONException, URISyntaxException {
-    event = mock(io.kuzzle.sdk.util.Event.class);
+    event = new io.kuzzle.sdk.util.Event(Event.offlineQueuePop) {
+      @Override
+      public void trigger(Object... args) {
+
+      }
+    };
+    eventSpy = spy(event);
     kuzzleExtend.setAutoReplay(true);
-    kuzzleExtend.addListener(Event.offlineQueuePop, event);
-    mockAnswer(Socket.EVENT_RECONNECT);
+    kuzzleExtend.addListener(Event.offlineQueuePop, eventSpy);
+    mockAnswer(Event.reconnected);
 
     Options opts = new Options().setQueuable(true);
     kuzzleExtend.setState(States.OFFLINE);
@@ -129,8 +143,6 @@ public class KuzzleListenerTest {
     kuzzleExtend.query(args, new JSONObject(), opts, mock(OnQueryDoneListener.class));
 
     kuzzleExtend.connect();
-    ArgumentCaptor argument = ArgumentCaptor.forClass(QueryObject.class);
-    verify(event).trigger(argument.capture());
-    assertEquals(((QueryObject) argument.getValue()).getQuery().getString("action"), "bar");
+    verify(eventSpy).trigger();
   }
 }

--- a/src/test/java/io/kuzzle/test/responses/SearchResultTest.java
+++ b/src/test/java/io/kuzzle/test/responses/SearchResultTest.java
@@ -19,7 +19,7 @@ import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.responses.SearchResult;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -44,7 +44,7 @@ public class SearchResultTest {
     options = new Options();
     options.setConnect(Mode.MANUAL);
     KuzzleExtend extended = new KuzzleExtend("localhost", options, null);
-    extended.setSocket(mock(Socket.class));
+    extended.setSocket(mock(WebSocketClient.class));
     extended.setState(States.CONNECTED);
     kuzzle = spy(extended);
     when(kuzzle.getHeaders()).thenReturn(new JSONObject());

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/createCredentialsTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/createCredentialsTest.java
@@ -2,12 +2,9 @@ package io.kuzzle.test.security.KuzzleSecurity;
 
 import io.kuzzle.sdk.core.Kuzzle;
 import io.kuzzle.sdk.core.Options;
-import io.kuzzle.sdk.enums.Mode;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.security.Security;
-import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -15,8 +12,6 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-
-import java.net.URISyntaxException;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/scrollProfilesTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/scrollProfilesTest.java
@@ -20,7 +20,7 @@ import io.kuzzle.sdk.security.Security;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.sdk.util.Scroll;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -46,7 +46,7 @@ public class scrollProfilesTest {
         Options opts = new Options();
         opts.setConnect(Mode.MANUAL);
         KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-        extended.setSocket(mock(Socket.class));
+        extended.setSocket(mock(WebSocketClient.class));
         extended.setState(States.CONNECTED);
         kuzzle = spy(extended);
         when(kuzzle.getHeaders()).thenReturn(new JSONObject());

--- a/src/test/java/io/kuzzle/test/security/KuzzleSecurity/scrollUsersTest.java
+++ b/src/test/java/io/kuzzle/test/security/KuzzleSecurity/scrollUsersTest.java
@@ -20,7 +20,7 @@ import io.kuzzle.sdk.security.Security;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.sdk.util.Scroll;
 import io.kuzzle.test.testUtils.KuzzleExtend;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -46,7 +46,7 @@ public class scrollUsersTest {
         Options opts = new Options();
         opts.setConnect(Mode.MANUAL);
         KuzzleExtend extended = new KuzzleExtend("localhost", opts, null);
-        extended.setSocket(mock(Socket.class));
+        extended.setSocket(mock(WebSocketClient.class));
         extended.setState(States.CONNECTED);
         kuzzle = spy(extended);
         when(kuzzle.getHeaders()).thenReturn(new JSONObject());

--- a/src/test/java/io/kuzzle/test/testUtils/KuzzleExtend.java
+++ b/src/test/java/io/kuzzle/test/testUtils/KuzzleExtend.java
@@ -19,12 +19,12 @@ import io.kuzzle.sdk.listeners.ResponseListener;
 import io.kuzzle.sdk.listeners.OnQueryDoneListener;
 import io.kuzzle.sdk.state.States;
 import io.kuzzle.sdk.util.EventList;
-import io.socket.client.Socket;
+import tech.gusavila92.websocketclient.WebSocketClient;
 
 import static org.mockito.Mockito.spy;
 
 public class KuzzleExtend extends Kuzzle {
-  protected Socket savedSocket = null;
+  protected WebSocketClient savedSocket = null;
 
   public ResponseListener loginCallback;
 
@@ -46,7 +46,7 @@ public class KuzzleExtend extends Kuzzle {
     this.state = newState;
   }
 
-  public void setSocket(Socket s) {
+  public void setSocket(WebSocketClient s) {
     this.socket = this.savedSocket = s;
   }
 
@@ -60,7 +60,7 @@ public class KuzzleExtend extends Kuzzle {
   }
 
 
-  protected Socket createSocket() throws URISyntaxException {
+  protected WebSocketClient createSocket() throws URISyntaxException {
     return this.savedSocket != null ? this.savedSocket : super.createSocket();
   }
 
@@ -86,7 +86,7 @@ public class KuzzleExtend extends Kuzzle {
    * Gets the internal socket instance from the kuzzle object
    * @return
    */
-  public Socket getSocket() {
+  public WebSocketClient getSocket() {
     return this.socket;
   }
 

--- a/src/test/java/io/kuzzle/test/testUtils/KuzzleExtend.java
+++ b/src/test/java/io/kuzzle/test/testUtils/KuzzleExtend.java
@@ -135,4 +135,10 @@ public class KuzzleExtend extends Kuzzle {
     super.jwtToken = token;
   }
 
+  public Kuzzle removeRoom(String channel) {
+    super.removeRoom(channel);
+
+    return this;
+  }
+
 }


### PR DESCRIPTION
## What does this PR do ?

Because the socketIO library we use in the SDK does not seem to be maintained anymore, I replaced it with a WebSocket library.
I also add Ssl support.